### PR TITLE
Scale quadrants to active screen resolution

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, BrowserView, session } = require('electron');
+const { app, BrowserWindow, BrowserView, session, screen } = require('electron');
 const path = require('path');
 
 const URLs = [
@@ -8,7 +8,7 @@ const URLs = [
   'https://xbox.com/play'
 ];
 
-function createView(x, y, index) {
+function createView(x, y, width, height, index) {
   const viewSession = session.fromPartition(`persist:player${index}`);
   const view = new BrowserView({
     webPreferences: {
@@ -17,21 +17,24 @@ function createView(x, y, index) {
       additionalArguments: [`--controllerIndex=${index}`]
     }
   });
-  view.setBounds({ x, y, width: 1920, height: 1080 });
+  view.setBounds({ x, y, width, height });
   view.webContents.loadURL(URLs[index]);
   return view;
 }
 
 function createWindow() {
+  const { width, height } = screen.getPrimaryDisplay().workAreaSize;
   const win = new BrowserWindow({ fullscreen: true, frame: false, autoHideMenuBar: true });
+  const viewWidth = Math.floor(width / 2);
+  const viewHeight = Math.floor(height / 2);
   const positions = [
-    { x: 0,    y: 0 },
-    { x: 1920, y: 0 },
-    { x: 0,    y: 1080 },
-    { x: 1920, y: 1080 }
+    { x: 0,         y: 0 },
+    { x: viewWidth, y: 0 },
+    { x: 0,         y: viewHeight },
+    { x: viewWidth, y: viewHeight }
   ];
   positions.forEach((pos, i) => {
-    const view = createView(pos.x, pos.y, i);
+    const view = createView(pos.x, pos.y, viewWidth, viewHeight, i);
     win.addBrowserView(view);
   });
 }

--- a/readme.MD
+++ b/readme.MD
@@ -1,6 +1,6 @@
 # Quad Play
 
-Electron app that splits a 4K screen into four isolated 1080p browser sessions for xCloud or Remote Play. Each view uses its own persistent profile and only listens to a single controller.
+Electron app that splits the display into four isolated browser sessions for xCloud or Remote Play. Each view scales to half of the screen's width and height—for example, on a 4K screen each view is 1080p, and on a 1080p screen each view is 540p. Every view uses its own persistent profile and only listens to a single controller.
 
 ## Windows setup
 
@@ -52,7 +52,7 @@ npm start
 ```
 
 
-Each quadrant loads `https://xbox.com/play` by default. Adjust the `URLs` array in [`main.js`](main.js) to point to other streaming services if needed.
+The app automatically splits the active display into four equal quadrants based on the screen resolution. Each quadrant loads `https://xbox.com/play` by default. Adjust the `URLs` array in [`main.js`](main.js) to point to other streaming services if needed.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Scale each BrowserView to half the screen size so layouts adapt to any display resolution.
- Clarify in documentation that the app automatically splits the display into four equal quadrants.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a33126598083218a0337c4ed91f021