### PR TITLE
Add hotkeys for quitting and quadrant activation

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, BrowserView, session, screen } = require('electron');
+const { app, BrowserWindow, BrowserView, session, screen, globalShortcut } = require('electron');
 const path = require('path');
 
 const URLs = [
@@ -22,6 +22,8 @@ function createView(x, y, width, height, index) {
   return view;
 }
 
+const views = [];
+
 function createWindow() {
   const { width, height } = screen.getPrimaryDisplay().workAreaSize;
   const win = new BrowserWindow({ fullscreen: true, frame: false, autoHideMenuBar: true });
@@ -36,7 +38,27 @@ function createWindow() {
   positions.forEach((pos, i) => {
     const view = createView(pos.x, pos.y, viewWidth, viewHeight, i);
     win.addBrowserView(view);
+    views[i] = view;
+  });
+  views[0].webContents.focus();
+}
+
+function registerShortcuts() {
+  globalShortcut.register('CommandOrControl+Q', () => {
+    app.quit();
+  });
+  views.forEach((view, i) => {
+    globalShortcut.register(`CommandOrControl+${i + 1}`, () => {
+      view.webContents.focus();
+    });
   });
 }
 
-app.whenReady().then(createWindow);
+app.whenReady().then(() => {
+  createWindow();
+  registerShortcuts();
+});
+
+app.on('will-quit', () => {
+  globalShortcut.unregisterAll();
+});

--- a/readme.MD
+++ b/readme.MD
@@ -59,3 +59,11 @@ The app automatically splits the active display into four equal quadrants based 
 - Works on Windows and Linux.
 - Gamepad filtering relies on the Gamepad API. Streaming services that read controllers directly from the OS may require additional tools for full isolation.
 
+## Hotkeys
+
+- **Ctrl+Q**: quit the application.
+- **Ctrl+1**: focus the top-left quadrant.
+- **Ctrl+2**: focus the top-right quadrant.
+- **Ctrl+3**: focus the bottom-left quadrant.
+- **Ctrl+4**: focus the bottom-right quadrant.
+


### PR DESCRIPTION
## Summary
- Add global shortcuts for quitting the app and focusing any of the four quadrants
- Document the new hotkeys in the README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a33396e9b48321a45d394a4d407338