### PR TITLE
Fix controller index parsing so each view handles its own gamepad

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -1,5 +1,5 @@
-const params = new URLSearchParams(global.process.argv.slice(1).join('&'));
-const myIndex = Number(params.get('controllerIndex') || 0);
+const arg = global.process.argv.find(a => a.startsWith('--controllerIndex='));
+const myIndex = arg ? Number(arg.split('=')[1]) : 0;
 
 const nativeGetGamepads = navigator.getGamepads.bind(navigator);
 


### PR DESCRIPTION
## Summary
- Parse `--controllerIndex` flag explicitly in the preload script so each view reads its own gamepad index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3369ae30c8321966d772a6cedf49b