### PR TITLE
Isolate controller input per quadrant

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, BrowserView, session, screen, globalShortcut } = require('electron');
+const { app, BrowserWindow, BrowserView, session, screen, globalShortcut, ipcMain } = require('electron');
 const path = require('path');
 
 const URLs = [
@@ -13,16 +13,20 @@ function createView(x, y, width, height, index) {
   const view = new BrowserView({
     webPreferences: {
       session: viewSession,
-      preload: path.join(__dirname, 'preload.js'),
-      additionalArguments: [`--controllerIndex=${index}`]
+      preload: path.join(__dirname, 'preload.js')
     }
   });
+  view.webContents.controllerIndex = index;
   view.setBounds({ x, y, width, height });
   view.webContents.loadURL(URLs[index]);
   return view;
 }
 
 const views = [];
+
+ipcMain.on('get-controller-index', (event) => {
+  event.returnValue = event.sender.controllerIndex || 0;
+});
 
 function createWindow() {
   // Use the full display size instead of the work area to avoid leaving

--- a/preload.js
+++ b/preload.js
@@ -1,19 +1,37 @@
-const arg = global.process.argv.find(a => a.startsWith('--controllerIndex='));
-const myIndex = arg ? Number(arg.split('=')[1]) : 0;
+const { ipcRenderer } = require('electron');
+const myIndex = ipcRenderer.sendSync('get-controller-index');
 
 const nativeGetGamepads = navigator.getGamepads.bind(navigator);
 
 navigator.getGamepads = () => {
   const gamepads = nativeGetGamepads();
-  return [gamepads[myIndex] || null];
+  const result = [null, null, null, null];
+  const pad = gamepads[myIndex];
+  if (pad) {
+    const proxied = new Proxy(pad, {
+      get(target, prop) {
+        return prop === 'index' ? 0 : target[prop];
+      }
+    });
+    result[0] = proxied;
+  }
+  return result;
 };
 
 window.addEventListener('gamepadconnected', ev => {
-  if (ev.gamepad.index !== myIndex) ev.stopImmediatePropagation();
+  if (ev.gamepad.index !== myIndex) {
+    ev.stopImmediatePropagation();
+  } else {
+    try { Object.defineProperty(ev.gamepad, 'index', { value: 0 }); } catch {}
+  }
 });
 
 window.addEventListener('gamepaddisconnected', ev => {
-  if (ev.gamepad.index !== myIndex) ev.stopImmediatePropagation();
+  if (ev.gamepad.index !== myIndex) {
+    ev.stopImmediatePropagation();
+  } else {
+    try { Object.defineProperty(ev.gamepad, 'index', { value: 0 }); } catch {}
+  }
 });
 
 let hideCursorTimeout;


### PR DESCRIPTION
## Summary
- pass controller index from main process to each view via IPC
- filter gamepad events per quadrant and ensure only assigned controller is exposed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a346013f388321ba8d3e858b0f24ae