### PR TITLE
feat: add self-updating start scripts

### DIFF
--- a/readme.MD
+++ b/readme.MD
@@ -4,43 +4,31 @@ Electron app that splits the display into four isolated browser sessions for xCl
 
 ## Windows setup
 
-1. **Install Git** – download and run the installer from [git-scm.com](https://git-scm.com/download/win) and accept the defaults.
-2. **Install Node.js** – download the LTS version from [nodejs.org](https://nodejs.org) and run the installer.
-3. Open **Git Bash** (installed with Git) or **Command Prompt**.
-4. Clone the repository and enter the folder:
-
-   ```bash
-   git clone https://github.com/your-username/quadcloud.git
-   cd quadcloud
-   ```
-
-5. (Optional) Download the Better XCloud script:
+1. **Install Node.js** – download the LTS version from [nodejs.org](https://nodejs.org) and run the installer.
+2. **Download the source** – grab the ZIP of this repository from GitHub and extract it.
+3. (Optional) Download the Better XCloud script:
 
    ```powershell
    powershell -Command "Invoke-WebRequest -Uri https://github.com/redphx/better-xcloud/releases/latest/download/better-xcloud.user.js -OutFile better-xcloud.user.js"
    ```
 
-6. Install dependencies and start the app:
-
-   ```bash
-   npm install
-   npm start
-   ```
+4. **Start the app** – run `start.bat`. The script updates the source from GitHub, installs the latest Electron and dependencies, and launches the application.
 
 ## Linux setup (Debian/Ubuntu)
 
-1. Install Git and Node.js:
+1. Install Node.js and required tools:
 
    ```bash
    sudo apt update
-   sudo apt install -y git nodejs npm
+   sudo apt install -y nodejs npm curl tar
    ```
 
-2. Clone the repository and enter the folder:
+2. Download and extract the source:
 
    ```bash
-   git clone https://github.com/your-username/quadcloud.git
-   cd quadcloud
+   curl -L -o quadcloud.tar.gz https://github.com/your-username/quadcloud/archive/refs/heads/main.tar.gz
+   tar -xzf quadcloud.tar.gz
+   cd quadcloud-main
    ```
 
 3. (Optional) Download the Better XCloud script:
@@ -49,11 +37,11 @@ Electron app that splits the display into four isolated browser sessions for xCl
    curl -L -o better-xcloud.user.js https://github.com/redphx/better-xcloud/releases/latest/download/better-xcloud.user.js
    ```
 
-4. Install dependencies and start the app:
+4. Start the app:
 
    ```bash
-   npm install
-   npm start
+   chmod +x start.sh
+   ./start.sh
    ```
 ## Usage
 

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,24 @@
+@echo off
+setlocal
+cd /d %~dp0
+
+set REPO_URL=https://github.com/your-username/quadcloud
+set BRANCH=main
+set TMP_DIR=%TEMP%\quadcloud_update
+
+echo Updating source...
+if exist "%TMP_DIR%" rd /s /q "%TMP_DIR%"
+mkdir "%TMP_DIR%"
+curl -L %REPO_URL%/archive/refs/heads/%BRANCH%.zip -o "%TMP_DIR%\update.zip"
+tar -xf "%TMP_DIR%\update.zip" -C "%TMP_DIR%"
+xcopy "%TMP_DIR%\quadcloud-%BRANCH%\*" . /E /Y >nul
+rd /s /q "%TMP_DIR%"
+
+echo Installing latest Electron...
+npm install electron@latest --save >nul
+
+echo Installing dependencies...
+npm install >nul
+
+echo Starting app...
+npm start

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")"
+
+REPO_URL="https://github.com/your-username/quadcloud"
+BRANCH="main"
+
+echo "Updating source..."
+TMP_DIR=$(mktemp -d)
+curl -L "$REPO_URL/archive/refs/heads/$BRANCH.tar.gz" | tar -xz -C "$TMP_DIR"
+cp -a "$TMP_DIR/quadcloud-$BRANCH/." .
+rm -rf "$TMP_DIR"
+
+echo "Installing latest Electron..."
+npm install electron@latest --save > /dev/null
+
+echo "Installing dependencies..."
+npm install > /dev/null
+
+echo "Starting app..."
+npm start


### PR DESCRIPTION
## Summary
- add Windows and Linux launchers that download fresh source, update Electron, install deps, and start the app
- drop Git requirement and document new start scripts for Windows and Linux

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4aa490ff483218220d33ed4e4da81