### PR TITLE
feat: add per-quadrant configuration panel

### DIFF
--- a/__tests__/config-ready.test.js
+++ b/__tests__/config-ready.test.js
@@ -1,0 +1,9 @@
+const sender = {};
+const configViews = [undefined, { webContents: sender }, undefined];
+
+describe('config-ready lookup', () => {
+  test('ignores empty slots', () => {
+    const index = configViews.findIndex(cv => cv && cv.webContents === sender);
+    expect(index).toBe(1);
+  });
+});

--- a/__tests__/profile-store.test.js
+++ b/__tests__/profile-store.test.js
@@ -29,4 +29,14 @@ describe('ProfileStore', () => {
     const store2 = new ProfileStore(file);
     expect(Object.keys(store2.getProfiles())).toHaveLength(6);
   });
+
+  test('persists audio assignments', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'profiles-'));
+    const file = path.join(tmp, 'profiles.json');
+    const store1 = new ProfileStore(file);
+    store1.assignAudio(1, 'device123');
+
+    const store2 = new ProfileStore(file);
+    expect(store2.getAudio(1)).toBe('device123');
+  });
 });

--- a/__tests__/profile-store.test.js
+++ b/__tests__/profile-store.test.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const ProfileStore = require('../lib/profile-store');
+
+describe('ProfileStore', () => {
+  test('creates and assigns profiles with persistence', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'profiles-'));
+    const file = path.join(tmp, 'profiles.json');
+    const store1 = new ProfileStore(file);
+    const id = store1.createProfile('Player');
+    store1.assignProfile(0, id);
+    store1.assignController(0, 2);
+
+    const store2 = new ProfileStore(file);
+    expect(store2.getProfiles()[id]).toBe('Player');
+    expect(store2.getAssignment(0)).toBe(id);
+    expect(store2.getController(0)).toBe(2);
+  });
+});

--- a/__tests__/profile-store.test.js
+++ b/__tests__/profile-store.test.js
@@ -17,4 +17,16 @@ describe('ProfileStore', () => {
     expect(store2.getAssignment(0)).toBe(id);
     expect(store2.getController(0)).toBe(2);
   });
+
+  test('allows creating more than four profiles', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'profiles-'));
+    const file = path.join(tmp, 'profiles.json');
+    const store1 = new ProfileStore(file);
+    for (let i = 0; i < 6; i++) {
+      store1.createProfile(`P${i}`);
+    }
+
+    const store2 = new ProfileStore(file);
+    expect(Object.keys(store2.getProfiles())).toHaveLength(6);
+  });
 });

--- a/__tests__/view-utils.test.js
+++ b/__tests__/view-utils.test.js
@@ -1,0 +1,14 @@
+const { destroyView } = require('../lib/view-utils');
+
+test('destroyView removes view and destroys its contents', () => {
+  const win = { removeBrowserView: jest.fn() };
+  const webContents = { destroy: jest.fn() };
+  const view = { webContents, destroy: jest.fn() };
+
+  destroyView(win, view);
+
+  expect(win.removeBrowserView).toHaveBeenCalledWith(view);
+  expect(webContents.destroy).toHaveBeenCalled();
+  expect(view.destroy).toHaveBeenCalled();
+});
+

--- a/assets/config.html
+++ b/assets/config.html
@@ -3,26 +3,74 @@
 <head>
   <meta charset="utf-8">
   <title>Player Settings</title>
+  <style>
+    body {
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+      font-family: sans-serif;
+      background: rgba(0, 0, 0, 0.5);
+      color: #000;
+    }
+    #panel {
+      background: #fff;
+      border: 1px solid #333;
+      padding: 16px;
+      border-radius: 8px;
+      min-width: 300px;
+    }
+    .row {
+      display: flex;
+      align-items: center;
+      margin-bottom: 8px;
+    }
+    .row label {
+      flex: 1;
+      margin-right: 8px;
+    }
+    .row select,
+    .row input {
+      flex: 2;
+    }
+    h1 {
+      margin-top: 0;
+      text-align: center;
+    }
+    button {
+      margin-left: 8px;
+    }
+  </style>
 </head>
 <body>
-  <h1>Player Settings</h1>
-  <div>
-    <label>Profile name <input id="profileName"></label>
-    <button id="saveName">Save Name</button>
+  <div id="panel">
+    <h1>Player Settings</h1>
+    <div class="row">
+      <label for="profileName">Profile name</label>
+      <input id="profileName">
+      <button id="saveName">Save Name</button>
+      <button id="newProfile">Add Profile</button>
+    </div>
+    <div class="row">
+      <label for="profileSelect">Profile</label>
+      <select id="profileSelect"></select>
+      <button id="applyProfile">Apply</button>
+    </div>
+    <div class="row">
+      <label for="controllerSelect">Controller</label>
+      <select id="controllerSelect"></select>
+      <button id="applyController">Apply</button>
+    </div>
+    <div class="row">
+      <label for="audioSelect">Audio Device</label>
+      <select id="audioSelect"></select>
+      <button id="applyAudio">Apply</button>
+    </div>
+    <div style="text-align: right;">
+      <button id="closeBtn">Close</button>
+    </div>
   </div>
-  <div>
-    <label>Profile <select id="profileSelect"></select></label>
-    <button id="applyProfile">Apply Profile</button>
-  </div>
-  <div>
-    <label>Controller <select id="controllerSelect"></select></label>
-    <button id="applyController">Apply Controller</button>
-  </div>
-  <div>
-    <label>Audio Device <select id="audioSelect"></select></label>
-    <button id="applyAudio">Apply Audio</button>
-  </div>
-  <button id="closeBtn">Close</button>
   <script src="config.js"></script>
 </body>
 </html>

--- a/assets/config.html
+++ b/assets/config.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Player Settings</title>
+</head>
+<body>
+  <h1>Player Settings</h1>
+  <div>
+    <label>Profile name <input id="profileName"></label>
+    <button id="saveName">Save Name</button>
+  </div>
+  <div>
+    <label>Profile <select id="profileSelect"></select></label>
+    <button id="applyProfile">Apply Profile</button>
+  </div>
+  <div>
+    <label>Controller <select id="controllerSelect"></select></label>
+    <button id="applyController">Apply Controller</button>
+  </div>
+  <div>
+    <label>Audio Device <select id="audioSelect"></select></label>
+    <button id="applyAudio">Apply Audio</button>
+  </div>
+  <button id="closeBtn">Close</button>
+  <script src="config.js"></script>
+</body>
+</html>

--- a/assets/config.js
+++ b/assets/config.js
@@ -1,0 +1,68 @@
+const { ipcRenderer } = require('electron');
+let viewIndex = null;
+
+ipcRenderer.on('init', (_e, data) => {
+  viewIndex = data.index;
+  document.getElementById('profileName').value = data.name || '';
+  fillProfiles(data.profiles, data.currentProfile);
+  fillControllers(data.controllers, data.currentController);
+  fillAudio(data.audioDevices, data.currentAudio);
+});
+
+function fillProfiles(profiles, current) {
+  const select = document.getElementById('profileSelect');
+  select.innerHTML = '';
+  Object.entries(profiles).forEach(([id, name]) => {
+    const opt = document.createElement('option');
+    opt.value = id;
+    opt.textContent = name;
+    if (id === current) opt.selected = true;
+    select.appendChild(opt);
+  });
+}
+
+function fillControllers(controllers, current) {
+  const select = document.getElementById('controllerSelect');
+  select.innerHTML = '';
+  controllers.forEach(idx => {
+    const opt = document.createElement('option');
+    opt.value = idx;
+    opt.textContent = `Controller ${idx}`;
+    if (idx === current) opt.selected = true;
+    select.appendChild(opt);
+  });
+}
+
+function fillAudio(devices, current) {
+  const select = document.getElementById('audioSelect');
+  select.innerHTML = '';
+  devices.forEach(dev => {
+    const opt = document.createElement('option');
+    opt.value = dev.deviceId;
+    opt.textContent = dev.label;
+    if (dev.deviceId === current) opt.selected = true;
+    select.appendChild(opt);
+  });
+}
+
+document.getElementById('saveName').addEventListener('click', () => {
+  ipcRenderer.send('rename-profile', { index: viewIndex, name: document.getElementById('profileName').value });
+});
+
+document.getElementById('applyProfile').addEventListener('click', () => {
+  ipcRenderer.send('select-profile', { index: viewIndex, profileId: document.getElementById('profileSelect').value });
+});
+
+document.getElementById('applyController').addEventListener('click', () => {
+  ipcRenderer.send('select-controller', { index: viewIndex, controller: parseInt(document.getElementById('controllerSelect').value, 10) });
+});
+
+document.getElementById('applyAudio').addEventListener('click', () => {
+  ipcRenderer.send('select-audio', { index: viewIndex, deviceId: document.getElementById('audioSelect').value });
+});
+
+document.getElementById('closeBtn').addEventListener('click', () => {
+  ipcRenderer.send('close-config', { index: viewIndex });
+});
+
+ipcRenderer.send('config-ready');

--- a/assets/config.js
+++ b/assets/config.js
@@ -6,7 +6,7 @@ ipcRenderer.on('init', (_e, data) => {
   document.getElementById('profileName').value = data.name || '';
   fillProfiles(data.profiles, data.currentProfile);
   fillControllers(data.controllers, data.currentController);
-  fillAudio(data.audioDevices, data.currentAudio);
+  enumerateAudio(data.currentAudio);
 });
 
 function fillProfiles(profiles, current) {
@@ -43,6 +43,15 @@ function fillAudio(devices, current) {
     if (dev.deviceId === current) opt.selected = true;
     select.appendChild(opt);
   });
+}
+
+async function enumerateAudio(current) {
+  try {
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    fillAudio(devices.filter(d => d.kind === 'audiooutput'), current);
+  } catch {
+    fillAudio([], current);
+  }
 }
 
 document.getElementById('saveName').addEventListener('click', () => {

--- a/assets/config.js
+++ b/assets/config.js
@@ -61,6 +61,10 @@ document.getElementById('applyAudio').addEventListener('click', () => {
   ipcRenderer.send('select-audio', { index: viewIndex, deviceId: document.getElementById('audioSelect').value });
 });
 
+document.getElementById('newProfile').addEventListener('click', () => {
+  ipcRenderer.send('create-profile', { index: viewIndex, name: document.getElementById('profileName').value });
+});
+
 document.getElementById('closeBtn').addEventListener('click', () => {
   ipcRenderer.send('close-config', { index: viewIndex });
 });

--- a/lib/profile-store.js
+++ b/lib/profile-store.js
@@ -25,7 +25,7 @@ class ProfileStore {
   }
 
   createProfile(name) {
-    const id = `profile${Date.now()}`;
+    const id = `profile${Date.now().toString(36)}${Math.random().toString(36).slice(2,8)}`;
     this.data.profiles[id] = name || id;
     this.save();
     return id;

--- a/lib/profile-store.js
+++ b/lib/profile-store.js
@@ -1,0 +1,72 @@
+const fs = require('fs');
+
+class ProfileStore {
+  constructor(file) {
+    this.file = file;
+    this.data = { profiles: {}, assignments: [], controllers: [], audio: [] };
+    this.load();
+  }
+
+  load() {
+    try {
+      const txt = fs.readFileSync(this.file, 'utf8');
+      this.data = JSON.parse(txt);
+    } catch {
+      // keep defaults
+    }
+  }
+
+  save() {
+    fs.writeFileSync(this.file, JSON.stringify(this.data, null, 2));
+  }
+
+  getProfiles() {
+    return this.data.profiles;
+  }
+
+  createProfile(name) {
+    const id = `profile${Date.now()}`;
+    this.data.profiles[id] = name || id;
+    this.save();
+    return id;
+  }
+
+  renameProfile(id, name) {
+    if (this.data.profiles[id]) {
+      this.data.profiles[id] = name;
+      this.save();
+    }
+  }
+
+  assignProfile(slot, id) {
+    this.data.assignments[slot] = id;
+    if (!this.data.profiles[id]) {
+      this.data.profiles[id] = id;
+    }
+    this.save();
+  }
+
+  getAssignment(slot) {
+    return this.data.assignments[slot];
+  }
+
+  assignController(slot, controller) {
+    this.data.controllers[slot] = controller;
+    this.save();
+  }
+
+  getController(slot) {
+    return this.data.controllers[slot];
+  }
+
+  assignAudio(slot, deviceId) {
+    this.data.audio[slot] = deviceId;
+    this.save();
+  }
+
+  getAudio(slot) {
+    return this.data.audio[slot];
+  }
+}
+
+module.exports = ProfileStore;

--- a/lib/view-utils.js
+++ b/lib/view-utils.js
@@ -1,0 +1,8 @@
+function destroyView(win, view) {
+  if (!view) return;
+  try { win.removeBrowserView(view); } catch {}
+  try { view.webContents.destroy(); } catch {}
+  try { if (typeof view.destroy === 'function') view.destroy(); } catch {}
+}
+
+module.exports = { destroyView };

--- a/main.js
+++ b/main.js
@@ -332,6 +332,14 @@ ipcMain.on('rename-profile', (_e, { index, name }) => {
   profileStore.renameProfile(id, name);
 });
 
+ipcMain.on('create-profile', (_e, { index, name }) => {
+  const id = profileStore.createProfile(name);
+  profileStore.assignProfile(index, id);
+  reloadView(index);
+  const cfg = configViews[index];
+  if (cfg) cfg.webContents.send('init', gatherConfigData(index));
+});
+
 ipcMain.on('select-profile', (_e, { index, profileId }) => {
   profileStore.assignProfile(index, profileId);
   reloadView(index);

--- a/main.js
+++ b/main.js
@@ -321,7 +321,7 @@ function registerShortcuts() {
 }
 
 ipcMain.on('config-ready', (e) => {
-  const index = configViews.findIndex(cv => cv.webContents === e.sender);
+  const index = configViews.findIndex(cv => cv && cv.webContents === e.sender);
   if (index !== -1) {
     e.sender.send('init', gatherConfigData(index));
   }

--- a/main.js
+++ b/main.js
@@ -251,7 +251,13 @@ function createWindow() {
     const controller = profileStore.getController(i);
     controllerAssignments[i] = controller ?? controllerAssignments[i];
     profileStore.assignController(i, controllerAssignments[i]);
+    const audio = profileStore.getAudio(i);
+    audioAssignments[i] = audio ?? audioAssignments[i];
+    profileStore.assignAudio(i, audioAssignments[i]);
     const view = createView(pos.x, pos.y, viewWidth, viewHeight, i, profileId, controllerAssignments[i]);
+    if (audioAssignments[i]) {
+      try { view.webContents.setAudioOutputDevice(audioAssignments[i]); } catch {}
+    }
     win.addBrowserView(view);
     views[i] = view;
   });
@@ -279,7 +285,6 @@ function gatherConfigData(index) {
     currentProfile: profileId,
     controllers: [0,1,2,3],
     currentController: controllerAssignments[index],
-    audioDevices: [],
     currentAudio: audioAssignments[index]
   };
 }
@@ -302,6 +307,10 @@ function reloadView(slot) {
   const profileId = profileStore.getAssignment(slot);
   const controller = controllerAssignments[slot];
   const view = createView(pos.x, pos.y, viewWidth, viewHeight, slot, profileId, controller);
+  const audio = audioAssignments[slot];
+  if (audio) {
+    try { view.webContents.setAudioOutputDevice(audio); } catch {}
+  }
   win.addBrowserView(view);
   views[slot] = view;
 }
@@ -312,10 +321,10 @@ function registerShortcuts() {
   });
   views.forEach((view, i) => {
     globalShortcut.register(`CommandOrControl+${i + 1}`, () => {
-      view.webContents.focus();
+      toggleConfig(i);
     });
     globalShortcut.register(`CommandOrControl+Alt+${i + 1}`, () => {
-      toggleConfig(i);
+      view.webContents.focus();
     });
   });
 }

--- a/main.js
+++ b/main.js
@@ -1,12 +1,23 @@
-const { app, BrowserWindow, BrowserView, session, screen, globalShortcut } = require('electron');
+const { app, BrowserWindow, BrowserView, session, screen, globalShortcut, ipcMain } = require('electron');
 const path = require('path');
 const fs = require('fs');
 const { XBOX_HOST_RE, getGamepadPatch } = require('./lib/xcloud');
+const ProfileStore = require('./lib/profile-store');
 
 app.commandLine.appendSwitch('disable-background-timer-throttling');
 app.commandLine.appendSwitch('disable-renderer-backgrounding');
 app.commandLine.appendSwitch('disable-backgrounding-occluded-windows');
 app.commandLine.appendSwitch('disable-features', 'HardwareMediaKeyHandling');
+
+let profileStore;
+const views = [];
+const configViews = [];
+let controllerAssignments = [0, 1, 2, 3];
+let audioAssignments = [];
+let win;
+let viewWidth = 0;
+let viewHeight = 0;
+let positions = [];
 
 
 // --- xCloud focus/visibility spoof: inject into MAIN WORLD + all frames ---
@@ -191,32 +202,30 @@ const URLs = [
   'https://xbox.com/play'
 ];
 
-function createView(x, y, width, height, index) {
-  const viewSession = session.fromPartition(`persist:player${index}`);
+function createView(x, y, width, height, slot, profileId, controllerIndex) {
+  const viewSession = session.fromPartition(`persist:${profileId}`);
   const view = new BrowserView({
     webPreferences: {
       session: viewSession,
       preload: path.join(__dirname, 'preload.js')
     }
   });
-  view.webContents.controllerIndex = index;
+  view.webContents.controllerIndex = controllerIndex;
   view.setBounds({ x, y, width, height });
   view.setAutoResize({ width: true, height: true });
   view.webContents.setBackgroundThrottling(false);
   installXcloudFocusWorkaround(view.webContents);
-  installGamepadIsolation(view.webContents, index);
+  installGamepadIsolation(view.webContents, controllerIndex);
   installBetterXcloud(view.webContents);
-  view.webContents.loadURL(URLs[index]);
+  view.webContents.loadURL(URLs[slot % URLs.length]);
   return view;
 }
-
-const views = [];
 
 function createWindow() {
   // Use the full display size instead of the work area to avoid leaving
   // a blank space where the taskbar would normally be.
   const { width, height } = screen.getPrimaryDisplay().size;
-  const win = new BrowserWindow({
+  win = new BrowserWindow({
     fullscreen: true,
     frame: false,
     autoHideMenuBar: true,
@@ -225,19 +234,76 @@ function createWindow() {
 
   win.loadFile(path.join(__dirname, 'background.html'));
 
-  const viewWidth = Math.floor(width / 2);
-  const viewHeight = Math.floor(height / 2);
-  const positions = [
+  viewWidth = Math.floor(width / 2);
+  viewHeight = Math.floor(height / 2);
+  positions = [
     { x: 0,         y: 0 },
     { x: viewWidth, y: 0 },
     { x: 0,         y: viewHeight },
     { x: viewWidth, y: viewHeight }
   ];
   positions.forEach((pos, i) => {
-    const view = createView(pos.x, pos.y, viewWidth, viewHeight, i);
+    let profileId = profileStore.getAssignment(i);
+    if (!profileId) {
+      profileId = profileStore.createProfile(`player${i + 1}`);
+      profileStore.assignProfile(i, profileId);
+    }
+    const controller = profileStore.getController(i);
+    controllerAssignments[i] = controller ?? controllerAssignments[i];
+    profileStore.assignController(i, controllerAssignments[i]);
+    const view = createView(pos.x, pos.y, viewWidth, viewHeight, i, profileId, controllerAssignments[i]);
     win.addBrowserView(view);
     views[i] = view;
   });
+}
+
+function getConfigView(index) {
+  let cfg = configViews[index];
+  if (cfg) return cfg;
+  cfg = new BrowserView({
+    webPreferences: { nodeIntegration: true, contextIsolation: false }
+  });
+  cfg.setBounds({ x: positions[index].x, y: positions[index].y, width: viewWidth, height: viewHeight });
+  cfg.setAutoResize({ width: true, height: true });
+  cfg.webContents.loadFile(path.join(__dirname, 'assets', 'config.html'));
+  configViews[index] = cfg;
+  return cfg;
+}
+
+function gatherConfigData(index) {
+  const profileId = profileStore.getAssignment(index);
+  return {
+    index,
+    name: profileStore.getProfiles()[profileId],
+    profiles: profileStore.getProfiles(),
+    currentProfile: profileId,
+    controllers: [0,1,2,3],
+    currentController: controllerAssignments[index],
+    audioDevices: [],
+    currentAudio: audioAssignments[index]
+  };
+}
+
+function toggleConfig(index) {
+  const cfg = getConfigView(index);
+  if (win.getBrowserViews().includes(cfg)) {
+    win.removeBrowserView(cfg);
+  } else {
+    cfg.setBounds({ x: positions[index].x, y: positions[index].y, width: viewWidth, height: viewHeight });
+    win.addBrowserView(cfg);
+    cfg.webContents.send('init', gatherConfigData(index));
+  }
+}
+
+function reloadView(slot) {
+  const pos = positions[slot];
+  const old = views[slot];
+  if (old) win.removeBrowserView(old);
+  const profileId = profileStore.getAssignment(slot);
+  const controller = controllerAssignments[slot];
+  const view = createView(pos.x, pos.y, viewWidth, viewHeight, slot, profileId, controller);
+  win.addBrowserView(view);
+  views[slot] = view;
 }
 
 function registerShortcuts() {
@@ -248,10 +314,49 @@ function registerShortcuts() {
     globalShortcut.register(`CommandOrControl+${i + 1}`, () => {
       view.webContents.focus();
     });
+    globalShortcut.register(`CommandOrControl+Alt+${i + 1}`, () => {
+      toggleConfig(i);
+    });
   });
 }
 
+ipcMain.on('config-ready', (e) => {
+  const index = configViews.findIndex(cv => cv.webContents === e.sender);
+  if (index !== -1) {
+    e.sender.send('init', gatherConfigData(index));
+  }
+});
+
+ipcMain.on('rename-profile', (_e, { index, name }) => {
+  const id = profileStore.getAssignment(index);
+  profileStore.renameProfile(id, name);
+});
+
+ipcMain.on('select-profile', (_e, { index, profileId }) => {
+  profileStore.assignProfile(index, profileId);
+  reloadView(index);
+});
+
+ipcMain.on('select-controller', (_e, { index, controller }) => {
+  controllerAssignments[index] = controller;
+  profileStore.assignController(index, controller);
+  reloadView(index);
+});
+
+ipcMain.on('select-audio', (_e, { index, deviceId }) => {
+  audioAssignments[index] = deviceId;
+  profileStore.assignAudio(index, deviceId);
+  const view = views[index];
+  try { view.webContents.setAudioOutputDevice(deviceId); } catch {}
+});
+
+ipcMain.on('close-config', (_e, { index }) => {
+  const cfg = configViews[index];
+  if (cfg) win.removeBrowserView(cfg);
+});
+
 app.whenReady().then(() => {
+  profileStore = new ProfileStore(path.join(app.getPath('userData'), 'profiles.json'));
   createWindow();
   registerShortcuts();
 });

--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@ const path = require('path');
 const fs = require('fs');
 const { XBOX_HOST_RE, getGamepadPatch } = require('./lib/xcloud');
 const ProfileStore = require('./lib/profile-store');
+const { destroyView } = require('./lib/view-utils');
 
 app.commandLine.appendSwitch('disable-background-timer-throttling');
 app.commandLine.appendSwitch('disable-renderer-backgrounding');
@@ -302,8 +303,7 @@ function toggleConfig(index) {
 
 function reloadView(slot) {
   const pos = positions[slot];
-  const old = views[slot];
-  if (old) win.removeBrowserView(old);
+  destroyView(win, views[slot]);
   const profileId = profileStore.getAssignment(slot);
   const controller = controllerAssignments[slot];
   const view = createView(pos.x, pos.y, viewWidth, viewHeight, slot, profileId, controller);
@@ -363,8 +363,7 @@ ipcMain.on('select-controller', (_e, { index, controller }) => {
 ipcMain.on('select-audio', (_e, { index, deviceId }) => {
   audioAssignments[index] = deviceId;
   profileStore.assignAudio(index, deviceId);
-  const view = views[index];
-  try { view.webContents.setAudioOutputDevice(deviceId); } catch {}
+  reloadView(index);
 });
 
 ipcMain.on('close-config', (_e, { index }) => {

--- a/readme.MD
+++ b/readme.MD
@@ -67,6 +67,8 @@ The app automatically splits the active display into four equal quadrants based 
 
 To avoid xCloud's "click to continue" overlay when a quadrant loses OS focus, the app spoofs focus in the main world of all `xbox.com` frames.
 
+Each quadrant also exposes a configuration panel (Ctrl+Alt+1–4) where you can rename or switch profiles, choose a controller, and pick an audio output device. Profile selections persist across sessions.
+
 ## Notes
 
 - Works on Windows and Linux.
@@ -79,6 +81,7 @@ To avoid xCloud's "click to continue" overlay when a quadrant loses OS focus, th
 - **Ctrl+2**: focus the top-right quadrant.
 - **Ctrl+3**: focus the bottom-left quadrant.
 - **Ctrl+4**: focus the bottom-right quadrant.
+- **Ctrl+Alt+1-4**: open the configuration panel for the corresponding quadrant.
 
 ## Testing
 

--- a/readme.MD
+++ b/readme.MD
@@ -67,7 +67,7 @@ The app automatically splits the active display into four equal quadrants based 
 
 To avoid xCloud's "click to continue" overlay when a quadrant loses OS focus, the app spoofs focus in the main world of all `xbox.com` frames.
 
-Each quadrant also exposes a configuration panel (Ctrl+Alt+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, choose a controller, and pick an audio output device. Profile selections persist across sessions.
+Each quadrant also exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, choose a controller, and pick an audio output device. Profile selections persist across sessions.
 
 ## Notes
 
@@ -77,11 +77,14 @@ Each quadrant also exposes a configuration panel (Ctrl+Alt+1–4) where you can 
 ## Hotkeys
 
 - **Ctrl+Q**: quit the application.
-- **Ctrl+1**: focus the top-left quadrant.
-- **Ctrl+2**: focus the top-right quadrant.
-- **Ctrl+3**: focus the bottom-left quadrant.
-- **Ctrl+4**: focus the bottom-right quadrant.
-- **Ctrl+Alt+1-4**: open the configuration panel for the corresponding quadrant.
+- **Ctrl+1**: open the configuration panel for the top-left quadrant.
+- **Ctrl+2**: open the configuration panel for the top-right quadrant.
+- **Ctrl+3**: open the configuration panel for the bottom-left quadrant.
+- **Ctrl+4**: open the configuration panel for the bottom-right quadrant.
+- **Ctrl+Alt+1**: focus the top-left quadrant.
+- **Ctrl+Alt+2**: focus the top-right quadrant.
+- **Ctrl+Alt+3**: focus the bottom-left quadrant.
+- **Ctrl+Alt+4**: focus the bottom-right quadrant.
 
 ## Testing
 

--- a/readme.MD
+++ b/readme.MD
@@ -67,7 +67,7 @@ The app automatically splits the active display into four equal quadrants based 
 
 To avoid xCloud's "click to continue" overlay when a quadrant loses OS focus, the app spoofs focus in the main world of all `xbox.com` frames.
 
-Each quadrant also exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, choose a controller, and pick an audio output device. Profile selections persist across sessions.
+Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, choose a controller, and pick an audio output device. Selecting a different controller or audio device reloads the quadrant so the previous stream is terminated. Profile selections persist across sessions.
 
 ## Notes
 

--- a/readme.MD
+++ b/readme.MD
@@ -67,7 +67,7 @@ The app automatically splits the active display into four equal quadrants based 
 
 To avoid xCloud's "click to continue" overlay when a quadrant loses OS focus, the app spoofs focus in the main world of all `xbox.com` frames.
 
-Each quadrant also exposes a configuration panel (Ctrl+Alt+1–4) where you can rename or switch profiles, choose a controller, and pick an audio output device. Profile selections persist across sessions.
+Each quadrant also exposes a configuration panel (Ctrl+Alt+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, choose a controller, and pick an audio output device. Profile selections persist across sessions.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- add profile store and persistent profile management
- introduce per-quadrant configuration panel with hotkeys
- document usage and new shortcuts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4ae8fc424832196619d79f5685cb4