### PR TITLE
Close control panel after applying reloadable settings

### DIFF
--- a/__tests__/close-config-view.test.js
+++ b/__tests__/close-config-view.test.js
@@ -1,0 +1,12 @@
+const { closeConfigView } = require('../lib/view-utils');
+
+test('closeConfigView removes config view and clears slot', () => {
+  const win = { removeBrowserView: jest.fn() };
+  const cfg = {};
+  const configViews = [cfg];
+
+  closeConfigView(win, configViews, 0);
+
+  expect(win.removeBrowserView).toHaveBeenCalledWith(cfg);
+  expect(configViews[0]).toBeUndefined();
+});

--- a/lib/view-utils.js
+++ b/lib/view-utils.js
@@ -5,4 +5,11 @@ function destroyView(win, view) {
   try { if (typeof view.destroy === 'function') view.destroy(); } catch {}
 }
 
-module.exports = { destroyView };
+function closeConfigView(win, configViews, index) {
+  const cfg = configViews[index];
+  if (!cfg) return;
+  try { win.removeBrowserView(cfg); } catch {}
+  configViews[index] = undefined;
+}
+
+module.exports = { destroyView, closeConfigView };

--- a/main.js
+++ b/main.js
@@ -3,7 +3,7 @@ const path = require('path');
 const fs = require('fs');
 const { XBOX_HOST_RE, getGamepadPatch } = require('./lib/xcloud');
 const ProfileStore = require('./lib/profile-store');
-const { destroyView } = require('./lib/view-utils');
+const { destroyView, closeConfigView } = require('./lib/view-utils');
 
 app.commandLine.appendSwitch('disable-background-timer-throttling');
 app.commandLine.appendSwitch('disable-renderer-backgrounding');
@@ -351,24 +351,26 @@ ipcMain.on('create-profile', (_e, { index, name }) => {
 
 ipcMain.on('select-profile', (_e, { index, profileId }) => {
   profileStore.assignProfile(index, profileId);
+  closeConfigView(win, configViews, index);
   reloadView(index);
 });
 
 ipcMain.on('select-controller', (_e, { index, controller }) => {
   controllerAssignments[index] = controller;
   profileStore.assignController(index, controller);
+  closeConfigView(win, configViews, index);
   reloadView(index);
 });
 
 ipcMain.on('select-audio', (_e, { index, deviceId }) => {
   audioAssignments[index] = deviceId;
   profileStore.assignAudio(index, deviceId);
+  closeConfigView(win, configViews, index);
   reloadView(index);
 });
 
 ipcMain.on('close-config', (_e, { index }) => {
-  const cfg = configViews[index];
-  if (cfg) win.removeBrowserView(cfg);
+  closeConfigView(win, configViews, index);
 });
 
 app.whenReady().then(() => {


### PR DESCRIPTION
## Summary
- ensure applying profile, controller, or audio changes closes the control panel
- add `closeConfigView` helper for removing config views and clearing slots
- test config view closing behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4bd1889f88321ab3d956bf8511e90