### PR TITLE
Route audio to selected output device with sinkId API

### DIFF
--- a/__tests__/audio.test.js
+++ b/__tests__/audio.test.js
@@ -7,5 +7,6 @@ describe('getAudioSinkPatch', () => {
     expect(patch).toContain(id);
     expect(patch).toMatch(/setSinkId/);
     expect(patch).toMatch(/AudioContext/);
+    expect(patch).toMatch(/window\.Audio/);
   });
 });

--- a/__tests__/audio.test.js
+++ b/__tests__/audio.test.js
@@ -1,0 +1,11 @@
+const { getAudioSinkPatch } = require('../lib/audio');
+
+describe('getAudioSinkPatch', () => {
+  test('includes device id and setSinkId calls', () => {
+    const id = 'dev123';
+    const patch = getAudioSinkPatch(id);
+    expect(patch).toContain(id);
+    expect(patch).toMatch(/setSinkId/);
+    expect(patch).toMatch(/AudioContext/);
+  });
+});

--- a/lib/audio.js
+++ b/lib/audio.js
@@ -1,0 +1,94 @@
+const getAudioSinkPatch = (deviceId) => `
+(() => {
+  const deviceId = ${JSON.stringify(deviceId)};
+  const setDevice = async id => {
+    try {
+      const media = document.querySelectorAll('audio,video');
+      for (const m of media) {
+        if (typeof m.setSinkId === 'function') {
+          try { await m.setSinkId(id); } catch {}
+        }
+      }
+      if (window.__quadAudioCtxs) {
+        for (const ctx of window.__quadAudioCtxs) {
+          if (typeof ctx.setSinkId === 'function') {
+            try { await ctx.setSinkId(id); } catch {}
+          }
+        }
+      }
+      window.__quadAudioDevice = id;
+    } catch {}
+  };
+  if (!window.__quadAudioCtxs) {
+    window.__quadAudioCtxs = [];
+    const AC = window.AudioContext || window.webkitAudioContext;
+    if (AC) {
+      const Wrapped = function(...args) {
+        const ctx = new AC(...args);
+        window.__quadAudioCtxs.push(ctx);
+        if (window.__quadAudioDevice && typeof ctx.setSinkId === 'function') {
+          ctx.setSinkId(window.__quadAudioDevice).catch(() => {});
+        }
+        return ctx;
+      };
+      Wrapped.prototype = AC.prototype;
+      window.AudioContext = window.webkitAudioContext = Wrapped;
+    }
+    const mo = new MutationObserver(muts => {
+      for (const m of muts) {
+        for (const node of m.addedNodes) {
+          if (node.nodeName === 'AUDIO' || node.nodeName === 'VIDEO') {
+            if (window.__quadAudioDevice && typeof node.setSinkId === 'function') {
+              try { node.setSinkId(window.__quadAudioDevice); } catch {}
+            }
+          } else if (node.querySelectorAll) {
+            node.querySelectorAll('audio,video').forEach(el => {
+              if (window.__quadAudioDevice && typeof el.setSinkId === 'function') {
+                try { el.setSinkId(window.__quadAudioDevice); } catch {}
+              }
+            });
+          }
+        }
+      }
+    });
+    try { mo.observe(document.documentElement, { childList: true, subtree: true }); } catch {}
+  }
+  setDevice(deviceId);
+})();
+`;
+
+function injectAudioSinkPatchIntoFrame(frame, deviceId) {
+  try { frame.executeJavaScript(getAudioSinkPatch(deviceId), true); } catch {}
+}
+
+function applyAudioSink(wc, deviceId) {
+  wc.__audioDevice = deviceId;
+  if (!deviceId) return;
+  try {
+    const mf = wc.mainFrame;
+    injectAudioSinkPatchIntoFrame(mf, deviceId);
+    for (const f of mf.frames) injectAudioSinkPatchIntoFrame(f, deviceId);
+  } catch {}
+}
+
+function installAudioSink(wc, deviceId) {
+  wc.__audioDevice = deviceId;
+  wc.on('dom-ready', () => applyAudioSink(wc, wc.__audioDevice));
+  wc.on('did-frame-navigate', (_e, details) => {
+    const id = wc.__audioDevice;
+    if (!id) return;
+    try {
+      const f = wc.mainFrame.frames.find(fr => fr.frameTreeNodeId === details.frameTreeNodeId);
+      if (f) injectAudioSinkPatchIntoFrame(f, id);
+    } catch {}
+  });
+  wc.on('frame-created', (_e, details) => {
+    const id = wc.__audioDevice;
+    if (!id) return;
+    try { injectAudioSinkPatchIntoFrame(details.frame, id); } catch {}
+  });
+  wc.on('did-start-navigation', () => applyAudioSink(wc, wc.__audioDevice));
+  applyAudioSink(wc, deviceId);
+}
+
+module.exports = { getAudioSinkPatch, installAudioSink, applyAudioSink };

--- a/lib/audio.js
+++ b/lib/audio.js
@@ -6,59 +6,113 @@ const getAudioSinkPatch = (deviceId) => `
       const media = document.querySelectorAll('audio,video');
       for (const m of media) {
         if (typeof m.setSinkId === 'function') {
-          try { await m.setSinkId(id); } catch {}
+          try {
+            await m.setSinkId(id);
+            console.debug('[quadcloud] setSinkId on element', m.nodeName, id);
+          } catch (err) {
+            console.warn('[quadcloud] setSinkId failed', err);
+          }
+        }
+      }
+      if (window.__quadAudios) {
+        for (const a of window.__quadAudios) {
+          if (typeof a.setSinkId === 'function') {
+            try {
+              await a.setSinkId(id);
+              console.debug('[quadcloud] setSinkId on Audio()', id);
+            } catch (err) {
+              console.warn('[quadcloud] setSinkId on Audio() failed', err);
+            }
+          }
         }
       }
       if (window.__quadAudioCtxs) {
         for (const ctx of window.__quadAudioCtxs) {
           if (typeof ctx.setSinkId === 'function') {
-            try { await ctx.setSinkId(id); } catch {}
+            try {
+              await ctx.setSinkId(id);
+              console.debug('[quadcloud] setSinkId on AudioContext', id);
+            } catch (err) {
+              console.warn('[quadcloud] setSinkId on AudioContext failed', err);
+            }
           }
         }
       }
       window.__quadAudioDevice = id;
-    } catch {}
+    } catch (err) {
+      console.warn('[quadcloud] setDevice failed', err);
+    }
   };
   if (!window.__quadAudioCtxs) {
     window.__quadAudioCtxs = [];
+    window.__quadAudios = [];
     const AC = window.AudioContext || window.webkitAudioContext;
     if (AC) {
       const Wrapped = function(...args) {
         const ctx = new AC(...args);
         window.__quadAudioCtxs.push(ctx);
         if (window.__quadAudioDevice && typeof ctx.setSinkId === 'function') {
-          ctx.setSinkId(window.__quadAudioDevice).catch(() => {});
+          ctx.setSinkId(window.__quadAudioDevice).catch(err => console.warn('[quadcloud] initial ctx setSinkId failed', err));
         }
         return ctx;
       };
       Wrapped.prototype = AC.prototype;
       window.AudioContext = window.webkitAudioContext = Wrapped;
     }
+    const Aud = window.Audio;
+    if (Aud) {
+      const WrappedAudio = function(...args) {
+        const a = new Aud(...args);
+        window.__quadAudios.push(a);
+        if (window.__quadAudioDevice && typeof a.setSinkId === 'function') {
+          a.setSinkId(window.__quadAudioDevice).catch(err => console.warn('[quadcloud] initial Audio() setSinkId failed', err));
+        }
+        return a;
+      };
+      WrappedAudio.prototype = Aud.prototype;
+      window.Audio = WrappedAudio;
+    }
     const mo = new MutationObserver(muts => {
       for (const m of muts) {
         for (const node of m.addedNodes) {
           if (node.nodeName === 'AUDIO' || node.nodeName === 'VIDEO') {
             if (window.__quadAudioDevice && typeof node.setSinkId === 'function') {
-              try { node.setSinkId(window.__quadAudioDevice); } catch {}
+              try {
+                node.setSinkId(window.__quadAudioDevice);
+                console.debug('[quadcloud] setSinkId on added node', node.nodeName);
+              } catch (err) {
+                console.warn('[quadcloud] setSinkId on added node failed', err);
+              }
             }
           } else if (node.querySelectorAll) {
             node.querySelectorAll('audio,video').forEach(el => {
               if (window.__quadAudioDevice && typeof el.setSinkId === 'function') {
-                try { el.setSinkId(window.__quadAudioDevice); } catch {}
+                try {
+                  el.setSinkId(window.__quadAudioDevice);
+                  console.debug('[quadcloud] setSinkId on added element', el.nodeName);
+                } catch (err) {
+                  console.warn('[quadcloud] setSinkId on added element failed', err);
+                }
               }
             });
           }
         }
       }
     });
-    try { mo.observe(document.documentElement, { childList: true, subtree: true }); } catch {}
+    try {
+      mo.observe(document.documentElement, { childList: true, subtree: true });
+    } catch (err) {
+      console.warn('[quadcloud] mutation observer failed', err);
+    }
   }
   setDevice(deviceId);
 })();
 `;
 
 function injectAudioSinkPatchIntoFrame(frame, deviceId) {
-  try { frame.executeJavaScript(getAudioSinkPatch(deviceId), true); } catch {}
+  try {
+    frame.executeJavaScript(getAudioSinkPatch(deviceId), true);
+  } catch {}
 }
 
 function applyAudioSink(wc, deviceId) {

--- a/main.js
+++ b/main.js
@@ -259,7 +259,12 @@ function createWindow() {
     profileStore.assignAudio(i, audioAssignments[i]);
     const view = createView(pos.x, pos.y, viewWidth, viewHeight, i, profileId, controllerAssignments[i], audioAssignments[i]);
     if (audioAssignments[i]) {
-      try { view.webContents.setAudioOutputDevice(audioAssignments[i]); } catch {}
+      try {
+        view.webContents.setAudioOutputDevice(audioAssignments[i]);
+        console.debug('[quadcloud] setAudioOutputDevice slot', i, audioAssignments[i]);
+      } catch (err) {
+        console.warn('[quadcloud] setAudioOutputDevice failed', err);
+      }
     }
     win.addBrowserView(view);
     views[i] = view;
@@ -311,7 +316,12 @@ function reloadView(slot) {
   const audio = audioAssignments[slot];
   const view = createView(pos.x, pos.y, viewWidth, viewHeight, slot, profileId, controller, audio);
   if (audio) {
-    try { view.webContents.setAudioOutputDevice(audio); } catch {}
+    try {
+      view.webContents.setAudioOutputDevice(audio);
+      console.debug('[quadcloud] setAudioOutputDevice slot', slot, audio);
+    } catch (err) {
+      console.warn('[quadcloud] setAudioOutputDevice failed', err);
+    }
   }
   win.addBrowserView(view);
   views[slot] = view;


### PR DESCRIPTION
## Summary
- add audio sink patch using `HTMLMediaElement.setSinkId` and `AudioContext.setSinkId`
- apply sink patch for each BrowserView to send sound to the chosen device
- test audio patch generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4ca987e5483219c55a90f4b5dfb27