### PR TITLE
Remove audio output override

### DIFF
--- a/__tests__/profile-store.test.js
+++ b/__tests__/profile-store.test.js
@@ -30,13 +30,4 @@ describe('ProfileStore', () => {
     expect(Object.keys(store2.getProfiles())).toHaveLength(6);
   });
 
-  test('persists audio assignments', () => {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'profiles-'));
-    const file = path.join(tmp, 'profiles.json');
-    const store1 = new ProfileStore(file);
-    store1.assignAudio(1, 'device123');
-
-    const store2 = new ProfileStore(file);
-    expect(store2.getAudio(1)).toBe('device123');
-  });
 });

--- a/assets/config.html
+++ b/assets/config.html
@@ -41,6 +41,12 @@
     button {
       margin-left: 8px;
     }
+    .note {
+      font-size: 0.8em;
+      margin-top: -4px;
+      margin-bottom: 8px;
+      text-align: center;
+    }
   </style>
 </head>
 <body>
@@ -65,8 +71,9 @@
     <div class="row">
       <label for="audioSelect">Audio Device</label>
       <select id="audioSelect"></select>
-      <button id="applyAudio">Apply</button>
+      <button id="applyAudio" disabled>Apply</button>
     </div>
+    <div class="note">Audio device selection is not implemented yet.</div>
     <div style="text-align: right;">
       <button id="closeBtn">Close</button>
     </div>

--- a/assets/config.js
+++ b/assets/config.js
@@ -6,7 +6,7 @@ ipcRenderer.on('init', (_e, data) => {
   document.getElementById('profileName').value = data.name || '';
   fillProfiles(data.profiles, data.currentProfile);
   fillControllers(data.controllers, data.currentController);
-  enumerateAudio(data.currentAudio);
+  enumerateAudio();
 });
 
 function fillProfiles(profiles, current) {
@@ -33,24 +33,23 @@ function fillControllers(controllers, current) {
   });
 }
 
-function fillAudio(devices, current) {
+function fillAudio(devices) {
   const select = document.getElementById('audioSelect');
   select.innerHTML = '';
   devices.forEach(dev => {
     const opt = document.createElement('option');
     opt.value = dev.deviceId;
     opt.textContent = dev.label;
-    if (dev.deviceId === current) opt.selected = true;
     select.appendChild(opt);
   });
 }
 
-async function enumerateAudio(current) {
+async function enumerateAudio() {
   try {
     const devices = await navigator.mediaDevices.enumerateDevices();
-    fillAudio(devices.filter(d => d.kind === 'audiooutput'), current);
+    fillAudio(devices.filter(d => d.kind === 'audiooutput'));
   } catch {
-    fillAudio([], current);
+    fillAudio([]);
   }
 }
 
@@ -66,9 +65,7 @@ document.getElementById('applyController').addEventListener('click', () => {
   ipcRenderer.send('select-controller', { index: viewIndex, controller: parseInt(document.getElementById('controllerSelect').value, 10) });
 });
 
-document.getElementById('applyAudio').addEventListener('click', () => {
-  ipcRenderer.send('select-audio', { index: viewIndex, deviceId: document.getElementById('audioSelect').value });
-});
+document.getElementById('applyAudio').disabled = true;
 
 document.getElementById('newProfile').addEventListener('click', () => {
   ipcRenderer.send('create-profile', { index: viewIndex, name: document.getElementById('profileName').value });

--- a/lib/profile-store.js
+++ b/lib/profile-store.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 class ProfileStore {
   constructor(file) {
     this.file = file;
-    this.data = { profiles: {}, assignments: [], controllers: [], audio: [] };
+    this.data = { profiles: {}, assignments: [], controllers: [] };
     this.load();
   }
 
@@ -59,14 +59,6 @@ class ProfileStore {
     return this.data.controllers[slot];
   }
 
-  assignAudio(slot, deviceId) {
-    this.data.audio[slot] = deviceId;
-    this.save();
-  }
-
-  getAudio(slot) {
-    return this.data.audio[slot];
-  }
 }
 
 module.exports = ProfileStore;

--- a/main.js
+++ b/main.js
@@ -14,7 +14,6 @@ let profileStore;
 const views = [];
 const configViews = [];
 let controllerAssignments = [0, 1, 2, 3];
-let audioAssignments = [];
 let win;
 let viewWidth = 0;
 let viewHeight = 0;
@@ -252,13 +251,7 @@ function createWindow() {
     const controller = profileStore.getController(i);
     controllerAssignments[i] = controller ?? controllerAssignments[i];
     profileStore.assignController(i, controllerAssignments[i]);
-    const audio = profileStore.getAudio(i);
-    audioAssignments[i] = audio ?? audioAssignments[i];
-    profileStore.assignAudio(i, audioAssignments[i]);
     const view = createView(pos.x, pos.y, viewWidth, viewHeight, i, profileId, controllerAssignments[i]);
-    if (audioAssignments[i]) {
-      try { view.webContents.setAudioOutputDevice(audioAssignments[i]); } catch {}
-    }
     win.addBrowserView(view);
     views[i] = view;
   });
@@ -285,8 +278,7 @@ function gatherConfigData(index) {
     profiles: profileStore.getProfiles(),
     currentProfile: profileId,
     controllers: [0,1,2,3],
-    currentController: controllerAssignments[index],
-    currentAudio: audioAssignments[index]
+    currentController: controllerAssignments[index]
   };
 }
 
@@ -307,10 +299,6 @@ function reloadView(slot) {
   const profileId = profileStore.getAssignment(slot);
   const controller = controllerAssignments[slot];
   const view = createView(pos.x, pos.y, viewWidth, viewHeight, slot, profileId, controller);
-  const audio = audioAssignments[slot];
-  if (audio) {
-    try { view.webContents.setAudioOutputDevice(audio); } catch {}
-  }
   win.addBrowserView(view);
   views[slot] = view;
 }
@@ -358,13 +346,6 @@ ipcMain.on('select-profile', (_e, { index, profileId }) => {
 ipcMain.on('select-controller', (_e, { index, controller }) => {
   controllerAssignments[index] = controller;
   profileStore.assignController(index, controller);
-  closeConfigView(win, configViews, index);
-  reloadView(index);
-});
-
-ipcMain.on('select-audio', (_e, { index, deviceId }) => {
-  audioAssignments[index] = deviceId;
-  profileStore.assignAudio(index, deviceId);
   closeConfigView(win, configViews, index);
   reloadView(index);
 });

--- a/readme.MD
+++ b/readme.MD
@@ -55,7 +55,7 @@ The app automatically splits the active display into four equal quadrants based 
 
 To avoid xCloud's "click to continue" overlay when a quadrant loses OS focus, the app spoofs focus in the main world of all `xbox.com` frames.
 
-Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, choose a controller, and pick an audio output device. Selecting a different controller or audio device reloads the quadrant so the previous stream is terminated. Profile selections persist across sessions.
+Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, and choose a controller. An audio device selector is present but not yet implemented. Selecting a different controller reloads the quadrant so the previous stream is terminated. Profile selections persist across sessions.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Drop all attempts to override audio output devices.
- Keep audio device selector in settings panel but disable it and note it's unimplemented.
- Update documentation to reflect lack of audio device support.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4ceeafadc832195d26712ac30bec9