### PR TITLE
feat: allow selecting audio output device

### DIFF
--- a/__tests__/audio-override.test.js
+++ b/__tests__/audio-override.test.js
@@ -1,0 +1,11 @@
+const { setAudioSink } = require('../lib/view-utils');
+
+test('setAudioSink executes script with sink id', () => {
+  const wc = { executeJavaScript: jest.fn() };
+  setAudioSink(wc, 'test-device');
+  expect(wc.executeJavaScript).toHaveBeenCalled();
+  const [script, userGesture] = wc.executeJavaScript.mock.calls[0];
+  expect(script).toContain('test-device');
+  expect(script).toContain('setSinkId');
+  expect(userGesture).toBe(true);
+});

--- a/assets/config.html
+++ b/assets/config.html
@@ -41,12 +41,6 @@
     button {
       margin-left: 8px;
     }
-    .note {
-      font-size: 0.8em;
-      margin-top: -4px;
-      margin-bottom: 8px;
-      text-align: center;
-    }
   </style>
 </head>
 <body>
@@ -71,9 +65,8 @@
     <div class="row">
       <label for="audioSelect">Audio Device</label>
       <select id="audioSelect"></select>
-      <button id="applyAudio" disabled>Apply</button>
+      <button id="applyAudio">Apply</button>
     </div>
-    <div class="note">Audio device selection is not implemented yet.</div>
     <div style="text-align: right;">
       <button id="closeBtn">Close</button>
     </div>

--- a/assets/config.js
+++ b/assets/config.js
@@ -42,6 +42,7 @@ function fillAudio(devices) {
     opt.textContent = dev.label;
     select.appendChild(opt);
   });
+  document.getElementById('applyAudio').disabled = devices.length === 0;
 }
 
 async function enumerateAudio() {
@@ -65,7 +66,12 @@ document.getElementById('applyController').addEventListener('click', () => {
   ipcRenderer.send('select-controller', { index: viewIndex, controller: parseInt(document.getElementById('controllerSelect').value, 10) });
 });
 
-document.getElementById('applyAudio').disabled = true;
+document.getElementById('applyAudio').addEventListener('click', () => {
+  ipcRenderer.send('select-audio', {
+    index: viewIndex,
+    deviceId: document.getElementById('audioSelect').value
+  });
+});
 
 document.getElementById('newProfile').addEventListener('click', () => {
   ipcRenderer.send('create-profile', { index: viewIndex, name: document.getElementById('profileName').value });

--- a/lib/view-utils.js
+++ b/lib/view-utils.js
@@ -12,4 +12,35 @@ function closeConfigView(win, configViews, index) {
   configViews[index] = undefined;
 }
 
-module.exports = { destroyView, closeConfigView };
+function setAudioSink(wc, deviceId) {
+  if (!wc || !deviceId) return;
+  const js = `(() => {
+    const sinkId = ${JSON.stringify(deviceId)};
+    const apply = root => {
+      for (const v of root.querySelectorAll('video')) {
+        if (typeof v.setSinkId === 'function') {
+          try { v.setSinkId(sinkId); } catch {}
+        }
+      }
+    };
+    apply(document);
+    if (!window.__quadAudioObserver) {
+      window.__quadAudioObserver = new MutationObserver(muts => {
+        for (const m of muts) {
+          for (const n of m.addedNodes) {
+            if (n.tagName === 'VIDEO') {
+              if (typeof n.setSinkId === 'function') try { n.setSinkId(window.__quadAudioSinkId); } catch {}
+            } else if (n.querySelectorAll) {
+              apply(n);
+            }
+          }
+        }
+      });
+      window.__quadAudioObserver.observe(document, { childList: true, subtree: true });
+    }
+    window.__quadAudioSinkId = sinkId;
+  })();`;
+  try { wc.executeJavaScript(js, true); } catch {}
+}
+
+module.exports = { destroyView, closeConfigView, setAudioSink };

--- a/main.js
+++ b/main.js
@@ -3,7 +3,7 @@ const path = require('path');
 const fs = require('fs');
 const { XBOX_HOST_RE, getGamepadPatch } = require('./lib/xcloud');
 const ProfileStore = require('./lib/profile-store');
-const { destroyView, closeConfigView } = require('./lib/view-utils');
+const { destroyView, closeConfigView, setAudioSink } = require('./lib/view-utils');
 
 app.commandLine.appendSwitch('disable-background-timer-throttling');
 app.commandLine.appendSwitch('disable-renderer-backgrounding');
@@ -204,6 +204,15 @@ const URLs = [
 
 function createView(x, y, width, height, slot, profileId, controllerIndex) {
   const viewSession = session.fromPartition(`persist:${profileId}`);
+  try {
+    viewSession.setPermissionRequestHandler((wc, permission, callback) => {
+      if (permission === 'speaker-selection') {
+        callback(true);
+      } else {
+        callback(false);
+      }
+    });
+  } catch {}
   const view = new BrowserView({
     webPreferences: {
       session: viewSession,
@@ -348,6 +357,12 @@ ipcMain.on('select-controller', (_e, { index, controller }) => {
   profileStore.assignController(index, controller);
   closeConfigView(win, configViews, index);
   reloadView(index);
+});
+
+ipcMain.on('select-audio', (_e, { index, deviceId }) => {
+  const view = views[index];
+  if (view) setAudioSink(view.webContents, deviceId);
+  closeConfigView(win, configViews, index);
 });
 
 ipcMain.on('close-config', (_e, { index }) => {

--- a/readme.MD
+++ b/readme.MD
@@ -55,7 +55,7 @@ The app automatically splits the active display into four equal quadrants based 
 
 To avoid xCloud's "click to continue" overlay when a quadrant loses OS focus, the app spoofs focus in the main world of all `xbox.com` frames.
 
-Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, and choose a controller. An audio device selector is present but not yet implemented. Selecting a different controller reloads the quadrant so the previous stream is terminated. Profile selections persist across sessions.
+Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, choose a controller, and pick an audio output device for that quadrant. Selecting a different controller reloads the quadrant so the previous stream is terminated. Profile selections persist across sessions.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- enable speaker-selection permission for each BrowserView
- support selecting audio output in config panel and apply using setSinkId
- document audio device override

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4db37c5748321b54dfe07793a8759