### PR TITLE
feat: allow selecting audio output device per quadrant

### DIFF
--- a/__tests__/audio-output.test.js
+++ b/__tests__/audio-output.test.js
@@ -1,0 +1,20 @@
+const { applyAudioOutput } = require('../lib/audio');
+
+test('applyAudioOutput injects selectAudioOutput and uses mainFrame', () => {
+  const executed = [];
+  const view = {
+    webContents: {
+      mainFrame: {
+        executeJavaScript: code => {
+          executed.push(code);
+          return Promise.resolve();
+        }
+      }
+    }
+  };
+
+  applyAudioOutput(view, 'my-device');
+  expect(executed).toHaveLength(1);
+  expect(executed[0]).toContain('navigator.mediaDevices.selectAudioOutput');
+  expect(executed[0]).toContain('my-device');
+});

--- a/__tests__/permissions.test.js
+++ b/__tests__/permissions.test.js
@@ -1,19 +1,29 @@
 const { allowMediaPermissions } = require('../lib/permissions');
 
-test('allowMediaPermissions approves media-related permissions', () => {
-  let handler;
+test('allowMediaPermissions wires handlers for allowed origins', () => {
+  let checkHandler;
+  let requestHandler;
   const ses = {
-    setPermissionRequestHandler: fn => { handler = fn; }
+    setPermissionCheckHandler: fn => { checkHandler = fn; },
+    setPermissionRequestHandler: fn => { requestHandler = fn; }
   };
   allowMediaPermissions(ses);
+
+  const allowed = 'https://xbox.com/play';
+  const denied = 'https://example.com/';
+
+  // check handler tests
+  expect(checkHandler({ getURL: () => allowed }, 'media', allowed, { requestingUrl: allowed })).toBe(true);
+  expect(checkHandler({ getURL: () => allowed }, 'speaker-selection', allowed, { requestingUrl: allowed })).toBe(true);
+  expect(checkHandler({ getURL: () => allowed }, 'geolocation', allowed, { requestingUrl: allowed })).toBe(false);
+  expect(checkHandler({ getURL: () => denied }, 'media', denied, { requestingUrl: denied })).toBe(false);
+
+  // request handler tests
   const results = {};
-  const perms = ['media', 'audioCapture', 'videoCapture', 'speakerSelection', 'geolocation'];
-  perms.forEach(p => {
-    handler(null, p, decision => { results[p] = decision; });
-  });
+  requestHandler({ getURL: () => allowed }, 'media', r => { results.media = r; }, { requestingUrl: allowed, mediaTypes: ['audio'] });
+  requestHandler({ getURL: () => allowed }, 'speaker-selection', r => { results.speaker = r; }, { requestingUrl: allowed });
+  requestHandler({ getURL: () => denied }, 'media', r => { results.denied = r; }, { requestingUrl: denied, mediaTypes: ['audio'] });
   expect(results.media).toBe(true);
-  expect(results.audioCapture).toBe(true);
-  expect(results.videoCapture).toBe(true);
-  expect(results.speakerSelection).toBe(true);
-  expect(results.geolocation).toBe(false);
+  expect(results.speaker).toBe(true);
+  expect(results.denied).toBe(false);
 });

--- a/__tests__/permissions.test.js
+++ b/__tests__/permissions.test.js
@@ -1,0 +1,19 @@
+const { allowMediaPermissions } = require('../lib/permissions');
+
+test('allowMediaPermissions approves media-related permissions', () => {
+  let handler;
+  const ses = {
+    setPermissionRequestHandler: fn => { handler = fn; }
+  };
+  allowMediaPermissions(ses);
+  const results = {};
+  const perms = ['media', 'audioCapture', 'videoCapture', 'speakerSelection', 'geolocation'];
+  perms.forEach(p => {
+    handler(null, p, decision => { results[p] = decision; });
+  });
+  expect(results.media).toBe(true);
+  expect(results.audioCapture).toBe(true);
+  expect(results.videoCapture).toBe(true);
+  expect(results.speakerSelection).toBe(true);
+  expect(results.geolocation).toBe(false);
+});

--- a/__tests__/profile-store.test.js
+++ b/__tests__/profile-store.test.js
@@ -11,11 +11,13 @@ describe('ProfileStore', () => {
     const id = store1.createProfile('Player');
     store1.assignProfile(0, id);
     store1.assignController(0, 2);
+    store1.assignAudio(0, 'device1');
 
     const store2 = new ProfileStore(file);
     expect(store2.getProfiles()[id]).toBe('Player');
     expect(store2.getAssignment(0)).toBe(id);
     expect(store2.getController(0)).toBe(2);
+    expect(store2.getAudio(0)).toBe('device1');
   });
 
   test('allows creating more than four profiles', () => {

--- a/assets/config.html
+++ b/assets/config.html
@@ -71,9 +71,8 @@
     <div class="row">
       <label for="audioSelect">Audio Device</label>
       <select id="audioSelect"></select>
-      <button id="applyAudio" disabled>Apply</button>
+      <button id="applyAudio">Apply</button>
     </div>
-    <div class="note">Audio device selection is not implemented yet.</div>
     <div style="text-align: right;">
       <button id="closeBtn">Close</button>
     </div>

--- a/assets/config.js
+++ b/assets/config.js
@@ -6,7 +6,7 @@ ipcRenderer.on('init', (_e, data) => {
   document.getElementById('profileName').value = data.name || '';
   fillProfiles(data.profiles, data.currentProfile);
   fillControllers(data.controllers, data.currentController);
-  enumerateAudio();
+  enumerateAudio(data.currentAudio);
 });
 
 function fillProfiles(profiles, current) {
@@ -33,23 +33,25 @@ function fillControllers(controllers, current) {
   });
 }
 
-function fillAudio(devices) {
+function fillAudio(devices, current) {
   const select = document.getElementById('audioSelect');
   select.innerHTML = '';
   devices.forEach(dev => {
     const opt = document.createElement('option');
     opt.value = dev.deviceId;
-    opt.textContent = dev.label;
+    opt.textContent = dev.label || dev.deviceId;
+    if (dev.deviceId === current) opt.selected = true;
     select.appendChild(opt);
   });
 }
 
-async function enumerateAudio() {
+async function enumerateAudio(current) {
   try {
+    await navigator.mediaDevices.getUserMedia({audio:true});
     const devices = await navigator.mediaDevices.enumerateDevices();
-    fillAudio(devices.filter(d => d.kind === 'audiooutput'));
+    fillAudio(devices.filter(d => d.kind === 'audiooutput'), current);
   } catch {
-    fillAudio([]);
+    fillAudio([], current);
   }
 }
 
@@ -65,7 +67,9 @@ document.getElementById('applyController').addEventListener('click', () => {
   ipcRenderer.send('select-controller', { index: viewIndex, controller: parseInt(document.getElementById('controllerSelect').value, 10) });
 });
 
-document.getElementById('applyAudio').disabled = true;
+document.getElementById('applyAudio').addEventListener('click', () => {
+  ipcRenderer.send('select-audio', { index: viewIndex, deviceId: document.getElementById('audioSelect').value });
+});
 
 document.getElementById('newProfile').addEventListener('click', () => {
   ipcRenderer.send('create-profile', { index: viewIndex, name: document.getElementById('profileName').value });

--- a/lib/audio.js
+++ b/lib/audio.js
@@ -1,0 +1,27 @@
+function applyAudioOutput(view, deviceId) {
+  if (!view) return;
+  const script = `
+    (async () => {
+      const preferredId = ${JSON.stringify(deviceId)};
+      async function pickId() {
+        try { await navigator.mediaDevices.selectAudioOutput(); } catch (e) {}
+        return preferredId || 'default';
+      }
+      const sinkId = await pickId();
+      function setAllMedia() {
+        const nodes = Array.from(document.querySelectorAll('audio, video'));
+        nodes.forEach(el => {
+          if (typeof el.setSinkId === 'function') {
+            el.setSinkId(sinkId).catch(err => console.warn('setSinkId failed', err));
+          }
+        });
+      }
+      setAllMedia();
+      const mo = new MutationObserver(setAllMedia);
+      mo.observe(document.documentElement, { childList: true, subtree: true });
+    })();
+  `;
+  try { view.webContents.mainFrame.executeJavaScript(script, true); } catch {}
+}
+
+module.exports = { applyAudioOutput };

--- a/lib/permissions.js
+++ b/lib/permissions.js
@@ -1,0 +1,12 @@
+function allowMediaPermissions(ses) {
+  if (!ses) return;
+  ses.setPermissionRequestHandler((wc, permission, callback) => {
+    if (['media', 'audioCapture', 'videoCapture', 'speakerSelection'].includes(permission)) {
+      callback(true);
+    } else {
+      callback(false);
+    }
+  });
+}
+
+module.exports = { allowMediaPermissions };

--- a/lib/permissions.js
+++ b/lib/permissions.js
@@ -1,10 +1,40 @@
+const { XBOX_HOST_RE } = require('./xcloud');
+
+const MEDIA_PERMS = new Set([
+  'media',
+  'audioCapture',
+  'videoCapture',
+  'speaker-selection',
+  'speakerSelection'
+]);
+
+function isAllowed(url) {
+  try {
+    const u = new URL(url);
+    if (u.protocol === 'file:') return true;
+    return XBOX_HOST_RE.test(u.hostname);
+  } catch {
+    return false;
+  }
+}
+
 function allowMediaPermissions(ses) {
   if (!ses) return;
-  ses.setPermissionRequestHandler((wc, permission, callback) => {
-    if (['media', 'audioCapture', 'videoCapture', 'speakerSelection'].includes(permission)) {
-      callback(true);
+
+  ses.setPermissionCheckHandler((wc, permission, requestingOrigin, details) => {
+    const url = requestingOrigin || details?.requestingUrl || wc?.getURL() || '';
+    if (!isAllowed(url)) return false;
+    return MEDIA_PERMS.has(permission);
+  });
+
+  ses.setPermissionRequestHandler((wc, permission, callback, details = {}) => {
+    const url = details.requestingUrl || wc?.getURL() || '';
+    const allowed = isAllowed(url) && MEDIA_PERMS.has(permission);
+    if (allowed && permission === 'media') {
+      const hasVideo = Array.isArray(details.mediaTypes) && details.mediaTypes.includes('video');
+      callback(!hasVideo);
     } else {
-      callback(false);
+      callback(allowed);
     }
   });
 }

--- a/lib/profile-store.js
+++ b/lib/profile-store.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 class ProfileStore {
   constructor(file) {
     this.file = file;
-    this.data = { profiles: {}, assignments: [], controllers: [] };
+    this.data = { profiles: {}, assignments: [], controllers: [], audio: [] };
     this.load();
   }
 
@@ -57,6 +57,15 @@ class ProfileStore {
 
   getController(slot) {
     return this.data.controllers[slot];
+  }
+
+  assignAudio(slot, deviceId) {
+    this.data.audio[slot] = deviceId;
+    this.save();
+  }
+
+  getAudio(slot) {
+    return this.data.audio[slot];
   }
 
 }

--- a/main.js
+++ b/main.js
@@ -19,6 +19,8 @@ let viewWidth = 0;
 let viewHeight = 0;
 let positions = [];
 
+const { allowMediaPermissions } = require('./lib/permissions');
+
 
 // --- xCloud focus/visibility spoof: inject into MAIN WORLD + all frames ---
 
@@ -221,6 +223,7 @@ const URLs = [
 
 function createView(x, y, width, height, slot, profileId, controllerIndex) {
   const viewSession = session.fromPartition(`persist:${profileId}`);
+  allowMediaPermissions(viewSession);
   const view = new BrowserView({
     webPreferences: {
       session: viewSession,
@@ -386,6 +389,7 @@ ipcMain.on('close-config', (_e, { index }) => {
 
 app.whenReady().then(() => {
   profileStore = new ProfileStore(path.join(app.getPath('userData'), 'profiles.json'));
+  allowMediaPermissions(session.defaultSession);
   createWindow();
   registerShortcuts();
 });

--- a/main.js
+++ b/main.js
@@ -20,6 +20,7 @@ let viewHeight = 0;
 let positions = [];
 
 const { allowMediaPermissions } = require('./lib/permissions');
+const { applyAudioOutput } = require('./lib/audio');
 
 
 // --- xCloud focus/visibility spoof: inject into MAIN WORLD + all frames ---
@@ -197,22 +198,6 @@ function installBetterXcloud(wc) {
   });
 }
 
-function applyAudioOutput(view, deviceId) {
-  if (!view || !deviceId) return;
-  const script = `
-    (async () => {
-      try { await navigator.mediaDevices.getUserMedia({audio:true}); } catch {}
-      const id = ${JSON.stringify(deviceId)};
-      const apply = el => { if (typeof el.setSinkId === 'function') { try { el.setSinkId(id); } catch {} } };
-      const setAll = () => document.querySelectorAll('audio,video').forEach(apply);
-      setAll();
-      new MutationObserver(m => m.forEach(r => r.addedNodes.forEach(n => {
-        if (n.tagName === 'AUDIO' || n.tagName === 'VIDEO') apply(n);
-      }))).observe(document.documentElement, {childList:true, subtree:true});
-    })();
-  `;
-  try { view.webContents.executeJavaScript(script, true); } catch {}
-}
 
 const URLs = [
   'https://xbox.com/play',

--- a/readme.MD
+++ b/readme.MD
@@ -55,7 +55,7 @@ The app automatically splits the active display into four equal quadrants based 
 
 To avoid xCloud's "click to continue" overlay when a quadrant loses OS focus, the app spoofs focus in the main world of all `xbox.com` frames.
 
-Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, choose a controller, and select an audio output device. Selecting a different controller reloads the quadrant so the previous stream is terminated. Profile and audio selections persist across sessions.
+Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, choose a controller, and select an audio output device. Selecting a different controller reloads the quadrant so the previous stream is terminated. Profile and audio selections persist across sessions. The app auto-grants microphone and speaker-selection permissions so no browser prompts appear.
 
 ## Notes
 

--- a/readme.MD
+++ b/readme.MD
@@ -55,7 +55,7 @@ The app automatically splits the active display into four equal quadrants based 
 
 To avoid xCloud's "click to continue" overlay when a quadrant loses OS focus, the app spoofs focus in the main world of all `xbox.com` frames.
 
-Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, and choose a controller. An audio device selector is present but not yet implemented. Selecting a different controller reloads the quadrant so the previous stream is terminated. Profile selections persist across sessions.
+Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, choose a controller, and select an audio output device. Selecting a different controller reloads the quadrant so the previous stream is terminated. Profile and audio selections persist across sessions.
 
 ## Notes
 

--- a/readme.MD
+++ b/readme.MD
@@ -55,7 +55,7 @@ The app automatically splits the active display into four equal quadrants based 
 
 To avoid xCloud's "click to continue" overlay when a quadrant loses OS focus, the app spoofs focus in the main world of all `xbox.com` frames.
 
-Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, choose a controller, and select an audio output device. Selecting a different controller reloads the quadrant so the previous stream is terminated. Profile and audio selections persist across sessions. The app auto-grants microphone and speaker-selection permissions so no browser prompts appear.
+Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, choose a controller, and select an audio output device. Selecting a different controller reloads the quadrant so the previous stream is terminated. Profile and audio selections persist across sessions. The app auto-grants microphone and speaker-selection permissions so no browser prompts appear, and changing the audio device silently runs `selectAudioOutput()` to let the site output through any speaker.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- persist audio device choice per quadrant
- apply selected sink to each browser view via setSinkId
- enable audio picker in config panel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4e4dc48e083219626e4fa56f783c0