### PR TITLE
feat: enable per-quadrant audio device override

### DIFF
--- a/__tests__/set-audio-output.test.js
+++ b/__tests__/set-audio-output.test.js
@@ -1,0 +1,12 @@
+const { setAudioOutput } = require('../lib/view-utils');
+
+test('setAudioOutput executes script with sink id', async () => {
+  const calls = [];
+  const view = { webContents: { executeJavaScript: jest.fn(script => { calls.push(script); return Promise.resolve(); }) } };
+  await setAudioOutput(view, 'device123');
+  expect(view.webContents.executeJavaScript).toHaveBeenCalled();
+  const script = calls[0];
+  expect(script).toContain('selectAudioOutput');
+  expect(script).toContain('setSinkId');
+  expect(script).toContain('device123');
+});

--- a/assets/config.html
+++ b/assets/config.html
@@ -71,9 +71,9 @@
     <div class="row">
       <label for="audioSelect">Audio Device</label>
       <select id="audioSelect"></select>
-      <button id="applyAudio" disabled>Apply</button>
+      <button id="applyAudio">Apply</button>
     </div>
-    <div class="note">Audio device selection is not implemented yet.</div>
+    <div class="note">Changing the audio device will prompt for permission.</div>
     <div style="text-align: right;">
       <button id="closeBtn">Close</button>
     </div>

--- a/assets/config.js
+++ b/assets/config.js
@@ -46,6 +46,9 @@ function fillAudio(devices) {
 
 async function enumerateAudio() {
   try {
+    if (navigator.mediaDevices?.selectAudioOutput) {
+      await navigator.mediaDevices.selectAudioOutput();
+    }
     const devices = await navigator.mediaDevices.enumerateDevices();
     fillAudio(devices.filter(d => d.kind === 'audiooutput'));
   } catch {
@@ -65,7 +68,9 @@ document.getElementById('applyController').addEventListener('click', () => {
   ipcRenderer.send('select-controller', { index: viewIndex, controller: parseInt(document.getElementById('controllerSelect').value, 10) });
 });
 
-document.getElementById('applyAudio').disabled = true;
+document.getElementById('applyAudio').addEventListener('click', () => {
+  ipcRenderer.send('select-audio', { index: viewIndex, deviceId: document.getElementById('audioSelect').value });
+});
 
 document.getElementById('newProfile').addEventListener('click', () => {
   ipcRenderer.send('create-profile', { index: viewIndex, name: document.getElementById('profileName').value });

--- a/lib/view-utils.js
+++ b/lib/view-utils.js
@@ -12,4 +12,26 @@ function closeConfigView(win, configViews, index) {
   configViews[index] = undefined;
 }
 
-module.exports = { destroyView, closeConfigView };
+async function setAudioOutput(view, deviceId) {
+  if (!view || !deviceId) return;
+  const js = `(
+    async () => {
+      try {
+        if (navigator.mediaDevices && navigator.mediaDevices.selectAudioOutput) {
+          await navigator.mediaDevices.selectAudioOutput();
+        }
+        const els = document.querySelectorAll('video,audio');
+        for (const el of els) {
+          if (typeof el.setSinkId === 'function') {
+            await el.setSinkId(${JSON.stringify(deviceId)});
+          }
+        }
+      } catch {}
+    }
+  )();`;
+  try {
+    await view.webContents.executeJavaScript(js, true);
+  } catch {}
+}
+
+module.exports = { destroyView, closeConfigView, setAudioOutput };

--- a/main.js
+++ b/main.js
@@ -3,7 +3,7 @@ const path = require('path');
 const fs = require('fs');
 const { XBOX_HOST_RE, getGamepadPatch } = require('./lib/xcloud');
 const ProfileStore = require('./lib/profile-store');
-const { destroyView, closeConfigView } = require('./lib/view-utils');
+const { destroyView, closeConfigView, setAudioOutput } = require('./lib/view-utils');
 
 app.commandLine.appendSwitch('disable-background-timer-throttling');
 app.commandLine.appendSwitch('disable-renderer-backgrounding');
@@ -348,6 +348,14 @@ ipcMain.on('select-controller', (_e, { index, controller }) => {
   profileStore.assignController(index, controller);
   closeConfigView(win, configViews, index);
   reloadView(index);
+});
+
+ipcMain.on('select-audio', (_e, { index, deviceId }) => {
+  const view = views[index];
+  if (view) {
+    setAudioOutput(view, deviceId);
+  }
+  closeConfigView(win, configViews, index);
 });
 
 ipcMain.on('close-config', (_e, { index }) => {

--- a/readme.MD
+++ b/readme.MD
@@ -55,7 +55,7 @@ The app automatically splits the active display into four equal quadrants based 
 
 To avoid xCloud's "click to continue" overlay when a quadrant loses OS focus, the app spoofs focus in the main world of all `xbox.com` frames.
 
-Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, and choose a controller. An audio device selector is present but not yet implemented. Selecting a different controller reloads the quadrant so the previous stream is terminated. Profile selections persist across sessions.
+Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, choose a controller, and override the audio output device. Selecting a different controller reloads the quadrant so the previous stream is terminated. Profile selections persist across sessions.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- enable audio output selection in config panel
- add setAudioOutput helper and hook IPC to override quadrant audio sink
- document audio override and test helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5f9485b588321bd63ea7eb7abf9d4