### PR TITLE
Add shortcut for developer tools

### DIFF
--- a/__tests__/register-shortcuts.test.js
+++ b/__tests__/register-shortcuts.test.js
@@ -1,0 +1,33 @@
+jest.mock('electron', () => ({
+  app: { quit: jest.fn() },
+  globalShortcut: { register: jest.fn() },
+  webContents: { getFocusedWebContents: jest.fn() }
+}));
+
+const registerShortcuts = require('../lib/register-shortcuts');
+const { globalShortcut, webContents } = require('electron');
+
+test('registers shortcut to open developer tools', () => {
+  const views = [];
+  const toggleConfig = jest.fn();
+  const callbacks = {};
+
+  globalShortcut.register.mockImplementation((accelerator, cb) => {
+    callbacks[accelerator] = cb;
+  });
+
+  registerShortcuts(views, toggleConfig);
+
+  expect(globalShortcut.register).toHaveBeenCalledWith(
+    'CommandOrControl+Alt+I',
+    expect.any(Function)
+  );
+
+  const openDevTools = jest.fn();
+  webContents.getFocusedWebContents.mockReturnValue({ openDevTools });
+
+  callbacks['CommandOrControl+Alt+I']();
+
+  expect(webContents.getFocusedWebContents).toHaveBeenCalled();
+  expect(openDevTools).toHaveBeenCalledWith({ mode: 'detach' });
+});

--- a/lib/register-shortcuts.js
+++ b/lib/register-shortcuts.js
@@ -1,0 +1,25 @@
+const { app, globalShortcut, webContents } = require('electron');
+
+function registerShortcuts(views, toggleConfig) {
+  globalShortcut.register('CommandOrControl+Q', () => {
+    app.quit();
+  });
+
+  globalShortcut.register('CommandOrControl+Alt+I', () => {
+    const wc = webContents.getFocusedWebContents();
+    if (wc) {
+      wc.openDevTools({ mode: 'detach' });
+    }
+  });
+
+  views.forEach((view, i) => {
+    globalShortcut.register(`CommandOrControl+${i + 1}`, () => {
+      toggleConfig(i);
+    });
+    globalShortcut.register(`CommandOrControl+Alt+${i + 1}`, () => {
+      view.webContents.focus();
+    });
+  });
+}
+
+module.exports = registerShortcuts;

--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
 const { app, BrowserWindow, BrowserView, session, screen, globalShortcut, ipcMain } = require('electron');
+const registerShortcuts = require('./lib/register-shortcuts');
 const path = require('path');
 const fs = require('fs');
 const { XBOX_HOST_RE, getGamepadPatch } = require('./lib/xcloud');
@@ -350,20 +351,6 @@ function applyAudioOutput(index, deviceId) {
   try { view.webContents.executeJavaScript(js); } catch {}
 }
 
-function registerShortcuts() {
-  globalShortcut.register('CommandOrControl+Q', () => {
-    app.quit();
-  });
-  views.forEach((view, i) => {
-    globalShortcut.register(`CommandOrControl+${i + 1}`, () => {
-      toggleConfig(i);
-    });
-    globalShortcut.register(`CommandOrControl+Alt+${i + 1}`, () => {
-      view.webContents.focus();
-    });
-  });
-}
-
 ipcMain.on('config-ready', (e) => {
   const index = configViews.findIndex(cv => cv && cv.webContents === e.sender);
   if (index !== -1) {
@@ -410,7 +397,7 @@ ipcMain.on('close-config', (_e, { index }) => {
 app.whenReady().then(() => {
   profileStore = new ProfileStore(path.join(app.getPath('userData'), 'profiles.json'));
   createWindow();
-  registerShortcuts();
+  registerShortcuts(views, toggleConfig);
 });
 
 app.on('will-quit', () => {

--- a/readme.MD
+++ b/readme.MD
@@ -73,6 +73,7 @@ Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or
 - **Ctrl+Alt+2**: focus the top-right quadrant.
 - **Ctrl+Alt+3**: focus the bottom-left quadrant.
 - **Ctrl+Alt+4**: focus the bottom-right quadrant.
+- **Ctrl+Alt+I**: open developer tools for the focused view.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- allow opening developer tools with Ctrl+Alt+I
- document new shortcut and refactor shortcut registration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a604da398c8321a93fb44ea7b7aee3