### PR TITLE
feat: add CSP headers for xCloud

### DIFF
--- a/__tests__/security-headers.test.js
+++ b/__tests__/security-headers.test.js
@@ -1,0 +1,17 @@
+const { addCspHeaders } = require('../lib/security-headers');
+
+describe('addCspHeaders', () => {
+  test('adds CSP and permissions policy for xbox hosts', () => {
+    const headers = addCspHeaders('https://www.xbox.com/play', {});
+    expect(headers['Content-Security-Policy']).toBeDefined();
+    expect(headers['Permissions-Policy']).toEqual([
+      'microphone=(self), speaker-selection=(self)'
+    ]);
+  });
+
+  test('ignores non-xbox hosts', () => {
+    const headers = addCspHeaders('https://example.com', {});
+    expect(headers['Permissions-Policy']).toBeUndefined();
+    expect(headers['Content-Security-Policy']).toBeUndefined();
+  });
+});

--- a/lib/security-headers.js
+++ b/lib/security-headers.js
@@ -1,0 +1,17 @@
+const { XBOX_HOST_RE } = require('./xcloud');
+
+function addCspHeaders(url, existing = {}) {
+  const headers = { ...existing };
+  try {
+    const host = new URL(url).hostname;
+    if (XBOX_HOST_RE.test(host)) {
+      headers['Content-Security-Policy'] = headers['Content-Security-Policy'] || ["default-src 'self'"];
+      headers['Permissions-Policy'] = headers['Permissions-Policy'] || ["microphone=(self), speaker-selection=(self)"];
+    }
+  } catch {
+    // ignore invalid URLs
+  }
+  return headers;
+}
+
+module.exports = { addCspHeaders };

--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@ const registerShortcuts = require('./lib/register-shortcuts');
 const path = require('path');
 const fs = require('fs');
 const { XBOX_HOST_RE, getGamepadPatch } = require('./lib/xcloud');
+const { addCspHeaders } = require('./lib/security-headers');
 const ProfileStore = require('./lib/profile-store');
 const { destroyView, closeConfigView } = require('./lib/view-utils');
 
@@ -10,6 +11,12 @@ app.commandLine.appendSwitch('disable-background-timer-throttling');
 app.commandLine.appendSwitch('disable-renderer-backgrounding');
 app.commandLine.appendSwitch('disable-backgrounding-occluded-windows');
 app.commandLine.appendSwitch('disable-features', 'HardwareMediaKeyHandling');
+
+// Inject security headers for xCloud content
+session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+  const responseHeaders = addCspHeaders(details.url, details.responseHeaders);
+  callback({ responseHeaders });
+});
 
 let profileStore;
 const views = [];

--- a/readme.MD
+++ b/readme.MD
@@ -55,6 +55,8 @@ The app automatically splits the active display into four equal quadrants based 
 
 To avoid xCloud's "click to continue" overlay when a quadrant loses OS focus, the app spoofs focus in the main world of all `xbox.com` frames.
 
+A Content Security Policy and permissions policy are injected into all `xbox.com` responses to allow microphone and speaker-selection features while restricting other resources.
+
 Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, choose a controller, and select an audio output device for that quadrant. Selecting a different controller reloads the quadrant so the previous stream is terminated. Profile selections persist across sessions.
 
 ## Notes


### PR DESCRIPTION
## Summary
- inject Content Security Policy and permissions headers on xbox.com responses to allow microphone and speaker-selection features
- document the new headers
- add unit tests for security header logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a60c014ea08321a88a4ad105c0abec