### PR TITLE
feat: allow mic and speaker selection via CSP

### DIFF
--- a/__tests__/security.test.js
+++ b/__tests__/security.test.js
@@ -1,0 +1,17 @@
+const { applySecurityHeaders } = require('../lib/security');
+
+describe('applySecurityHeaders', () => {
+  test('adds headers for xbox hosts', () => {
+    const details = { url: 'https://xbox.com/play', responseHeaders: {} };
+    const { responseHeaders } = applySecurityHeaders(details);
+    expect(responseHeaders['Content-Security-Policy']).toEqual(["default-src 'self'"]);
+    expect(responseHeaders['Permissions-Policy']).toEqual(['microphone=*, speaker-selection=*']);
+  });
+
+  test('ignores non xbox hosts', () => {
+    const details = { url: 'https://example.com', responseHeaders: {} };
+    const { responseHeaders } = applySecurityHeaders(details);
+    expect(responseHeaders['Content-Security-Policy']).toBeUndefined();
+    expect(responseHeaders['Permissions-Policy']).toBeUndefined();
+  });
+});

--- a/lib/security.js
+++ b/lib/security.js
@@ -1,0 +1,15 @@
+const { XBOX_HOST_RE } = require('./xcloud');
+
+function applySecurityHeaders(details) {
+  const responseHeaders = { ...(details.responseHeaders || {}) };
+  try {
+    const { hostname } = new URL(details.url);
+    if (XBOX_HOST_RE.test(hostname)) {
+      responseHeaders['Content-Security-Policy'] = ["default-src 'self'"];
+      responseHeaders['Permissions-Policy'] = ['microphone=*, speaker-selection=*'];
+    }
+  } catch {}
+  return { responseHeaders };
+}
+
+module.exports = { applySecurityHeaders };

--- a/main.js
+++ b/main.js
@@ -5,11 +5,16 @@ const fs = require('fs');
 const { XBOX_HOST_RE, getGamepadPatch } = require('./lib/xcloud');
 const ProfileStore = require('./lib/profile-store');
 const { destroyView, closeConfigView } = require('./lib/view-utils');
+const { applySecurityHeaders } = require('./lib/security');
 
 app.commandLine.appendSwitch('disable-background-timer-throttling');
 app.commandLine.appendSwitch('disable-renderer-backgrounding');
 app.commandLine.appendSwitch('disable-backgrounding-occluded-windows');
 app.commandLine.appendSwitch('disable-features', 'HardwareMediaKeyHandling');
+
+session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+  callback(applySecurityHeaders(details));
+});
 
 let profileStore;
 const views = [];

--- a/readme.MD
+++ b/readme.MD
@@ -61,6 +61,7 @@ Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or
 
 - Works on Windows and Linux.
 - Gamepad filtering relies on the Gamepad API. Streaming services that read controllers directly from the OS may require additional tools for full isolation.
+- Applies a Content Security Policy and permissions policy enabling microphone use and speaker selection for xCloud pages.
 
 ## Hotkeys
 


### PR DESCRIPTION
## Summary
- inject CSP and permissions headers for xCloud content
- document new security headers
- add tests for security headers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a60c014ea08321a88a4ad105c0abec