### PR TITLE
Inject in-view speaker selection via Ctrl+S

### DIFF
--- a/__tests__/register-shortcuts.test.js
+++ b/__tests__/register-shortcuts.test.js
@@ -31,3 +31,31 @@ test('registers shortcut to open developer tools', () => {
   expect(webContents.getFocusedWebContents).toHaveBeenCalled();
   expect(openDevTools).toHaveBeenCalledWith({ mode: 'detach' });
 });
+
+test('registers shortcut to open audio selection dialog', () => {
+  const views = [];
+  const toggleConfig = jest.fn();
+  const callbacks = {};
+
+  globalShortcut.register.mockClear();
+  webContents.getFocusedWebContents.mockReset();
+
+  globalShortcut.register.mockImplementation((accelerator, cb) => {
+    callbacks[accelerator] = cb;
+  });
+
+  registerShortcuts(views, toggleConfig);
+
+  expect(globalShortcut.register).toHaveBeenCalledWith(
+    'CommandOrControl+S',
+    expect.any(Function)
+  );
+
+  const executeJavaScript = jest.fn();
+  webContents.getFocusedWebContents.mockReturnValue({ executeJavaScript });
+
+  callbacks['CommandOrControl+S']();
+
+  expect(webContents.getFocusedWebContents).toHaveBeenCalled();
+  expect(executeJavaScript).toHaveBeenCalled();
+});

--- a/assets/config.html
+++ b/assets/config.html
@@ -41,12 +41,6 @@
     button {
       margin-left: 8px;
     }
-    .note {
-      font-size: 0.8em;
-      margin-top: -4px;
-      margin-bottom: 8px;
-      text-align: center;
-    }
   </style>
 </head>
 <body>
@@ -68,12 +62,6 @@
       <select id="controllerSelect"></select>
       <button id="applyController">Apply</button>
     </div>
-    <div class="row">
-      <label for="audioSelect">Audio Device</label>
-      <select id="audioSelect"></select>
-      <button id="applyAudio">Apply</button>
-    </div>
-    <div class="note">Choose which speakers this quadrant should use.</div>
     <div style="text-align: right;">
       <button id="closeBtn">Close</button>
     </div>

--- a/assets/config.js
+++ b/assets/config.js
@@ -6,7 +6,7 @@ ipcRenderer.on('init', (_e, data) => {
   document.getElementById('profileName').value = data.name || '';
   fillProfiles(data.profiles, data.currentProfile);
   fillControllers(data.controllers, data.currentController);
-  enumerateAudio(data.currentAudio);
+  enumerateAudio();
 });
 
 function fillProfiles(profiles, current) {
@@ -33,26 +33,10 @@ function fillControllers(controllers, current) {
   });
 }
 
-function fillAudio(devices, current) {
-  const select = document.getElementById('audioSelect');
-  select.innerHTML = '';
-  devices.forEach(dev => {
-    const opt = document.createElement('option');
-    opt.value = dev.deviceId;
-    opt.textContent = dev.label;
-     if (dev.deviceId === current) opt.selected = true;
-    select.appendChild(opt);
-  });
-  document.getElementById('applyAudio').disabled = devices.length === 0;
-}
-
-async function enumerateAudio(current) {
+async function enumerateAudio() {
   try {
-    const devices = await navigator.mediaDevices.enumerateDevices();
-    fillAudio(devices.filter(d => d.kind === 'audiooutput'), current);
-  } catch {
-    fillAudio([], current);
-  }
+    await navigator.mediaDevices.enumerateDevices();
+  } catch {}
 }
 
 document.getElementById('saveName').addEventListener('click', () => {
@@ -65,10 +49,6 @@ document.getElementById('applyProfile').addEventListener('click', () => {
 
 document.getElementById('applyController').addEventListener('click', () => {
   ipcRenderer.send('select-controller', { index: viewIndex, controller: parseInt(document.getElementById('controllerSelect').value, 10) });
-});
-
-document.getElementById('applyAudio').addEventListener('click', () => {
-  ipcRenderer.send('select-audio', { index: viewIndex, deviceId: document.getElementById('audioSelect').value });
 });
 
 document.getElementById('newProfile').addEventListener('click', () => {

--- a/lib/register-shortcuts.js
+++ b/lib/register-shortcuts.js
@@ -1,5 +1,72 @@
 const { app, globalShortcut, webContents } = require('electron');
 
+const AUDIO_DIALOG_JS = `
+(() => {
+  const existing = document.getElementById('qc-audio-dialog');
+  if (existing) { existing.remove(); return; }
+  const overlay = document.createElement('div');
+  overlay.id = 'qc-audio-dialog';
+  overlay.style.position = 'fixed';
+  overlay.style.top = '0';
+  overlay.style.left = '0';
+  overlay.style.right = '0';
+  overlay.style.bottom = '0';
+  overlay.style.background = 'rgba(0,0,0,0.6)';
+  overlay.style.display = 'flex';
+  overlay.style.alignItems = 'center';
+  overlay.style.justifyContent = 'center';
+  overlay.style.zIndex = '999999';
+
+  const panel = document.createElement('div');
+  panel.style.background = '#fff';
+  panel.style.padding = '20px';
+  panel.style.borderRadius = '8px';
+  panel.style.color = '#000';
+
+  const select = document.createElement('select');
+  select.style.minWidth = '200px';
+
+  const apply = document.createElement('button');
+  apply.textContent = 'Apply';
+  apply.style.marginLeft = '8px';
+
+  const cancel = document.createElement('button');
+  cancel.textContent = 'Cancel';
+  cancel.style.marginLeft = '8px';
+
+  panel.appendChild(select);
+  panel.appendChild(apply);
+  panel.appendChild(cancel);
+  overlay.appendChild(panel);
+  document.body.appendChild(overlay);
+
+  navigator.mediaDevices.enumerateDevices().then(devs => {
+    devs.filter(d => d.kind === 'audiooutput').forEach(d => {
+      const opt = document.createElement('option');
+      opt.value = d.deviceId;
+      opt.textContent = d.label || 'Device';
+      select.appendChild(opt);
+    });
+  });
+
+  apply.addEventListener('click', async () => {
+    const id = select.value;
+    if (navigator.mediaDevices && navigator.mediaDevices.selectAudioOutput) {
+      try { await navigator.mediaDevices.selectAudioOutput({ deviceId: id }); } catch {}
+    }
+    const els = document.querySelectorAll('audio, video');
+    for (const el of els) {
+      if (typeof el.setSinkId === 'function') {
+        try { await el.setSinkId(id); } catch {}
+      }
+    }
+    overlay.remove();
+  });
+
+  cancel.addEventListener('click', () => overlay.remove());
+})();
+`;
+
 function registerShortcuts(views, toggleConfig) {
   globalShortcut.register('CommandOrControl+Q', () => {
     app.quit();
@@ -9,6 +76,13 @@ function registerShortcuts(views, toggleConfig) {
     const wc = webContents.getFocusedWebContents();
     if (wc) {
       wc.openDevTools({ mode: 'detach' });
+    }
+  });
+
+  globalShortcut.register('CommandOrControl+S', () => {
+    const wc = webContents.getFocusedWebContents();
+    if (wc) {
+      try { wc.executeJavaScript(AUDIO_DIALOG_JS); } catch {}
     }
   });
 

--- a/readme.MD
+++ b/readme.MD
@@ -55,7 +55,7 @@ The app automatically splits the active display into four equal quadrants based 
 
 To avoid xCloud's "click to continue" overlay when a quadrant loses OS focus, the app spoofs focus in the main world of all `xbox.com` frames.
 
-Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, choose a controller, and select an audio output device for that quadrant. Selecting a different controller reloads the quadrant so the previous stream is terminated. Profile selections persist across sessions.
+Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, and choose a controller. Selecting a different controller reloads the quadrant so the previous stream is terminated. Profile selections persist across sessions. Press Ctrl+S in a focused quadrant to choose its audio output device directly within the stream.
 
 ## Notes
 
@@ -74,6 +74,7 @@ Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or
 - **Ctrl+Alt+3**: focus the bottom-left quadrant.
 - **Ctrl+Alt+4**: focus the bottom-right quadrant.
 - **Ctrl+Alt+I**: open developer tools for the focused view.
+- **Ctrl+S**: open the speaker selection dialog for the focused quadrant.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- Remove audio device dropdown from config panel while keeping device permission logic
- Add global Ctrl+S shortcut that injects an in-renderer audio selector dialog
- Document new shortcut and update tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a60c68ce7883218fd56f593257dd3c