### PR TITLE
feat: auto map xbox controllers

### DIFF
--- a/__tests__/xcloud.test.js
+++ b/__tests__/xcloud.test.js
@@ -1,4 +1,4 @@
-const { isXboxHost, getGamepadPatch } = require('../lib/xcloud');
+const { isXboxHost, getGamepadPatch, getControllerSlot } = require('../lib/xcloud');
 
 describe('isXboxHost', () => {
   test('matches xbox.com and subdomains', () => {
@@ -16,5 +16,19 @@ describe('getGamepadPatch', () => {
   test('includes provided controller index', () => {
     const patch = getGamepadPatch(2);
     expect(patch).toContain('const myIndex = 2;');
+  });
+});
+
+describe('getControllerSlot', () => {
+  test('maps numbered controllers', () => {
+    expect(getControllerSlot('Xbox Controller 3')).toBe(2);
+  });
+
+  test('maps unnumbered controller to zero', () => {
+    expect(getControllerSlot('Xbox Controller')).toBe(0);
+  });
+
+  test('returns null for other names', () => {
+    expect(getControllerSlot('Generic Gamepad')).toBeNull();
   });
 });

--- a/lib/xcloud.js
+++ b/lib/xcloud.js
@@ -51,8 +51,17 @@ function getGamepadPatch(index) {
 })()`;
 }
 
+function getControllerSlot(id) {
+  if (typeof id !== 'string') return null;
+  const match = /^Xbox Controller(?:\s*(\d))?$/i.exec(id.trim());
+  if (!match) return null;
+  const num = match[1] ? parseInt(match[1], 10) : 1;
+  return num - 1;
+}
+
 module.exports = {
   XBOX_HOST_RE,
   isXboxHost,
-  getGamepadPatch
+  getGamepadPatch,
+  getControllerSlot
 };

--- a/main.js
+++ b/main.js
@@ -2,7 +2,7 @@ const { app, BrowserWindow, BrowserView, session, screen, globalShortcut, ipcMai
 const registerShortcuts = require('./lib/register-shortcuts');
 const path = require('path');
 const fs = require('fs');
-const { XBOX_HOST_RE, getGamepadPatch } = require('./lib/xcloud');
+const { XBOX_HOST_RE, getGamepadPatch, getControllerSlot } = require('./lib/xcloud');
 const ProfileStore = require('./lib/profile-store');
 const { destroyView, closeConfigView } = require('./lib/view-utils');
 
@@ -382,6 +382,16 @@ ipcMain.on('select-controller', (_e, { index, controller }) => {
   profileStore.assignController(index, controller);
   closeConfigView(win, configViews, index);
   reloadView(index);
+});
+
+ipcMain.on('gamepad-connected', (e, { id, index }) => {
+  const slot = getControllerSlot(id);
+  if (slot == null) return;
+  if (controllerAssignments[slot] !== index) {
+    controllerAssignments[slot] = index;
+    profileStore.assignController(slot, index);
+    reloadView(slot);
+  }
 });
 
 ipcMain.on('select-audio', (_e, { index, deviceId }) => {

--- a/preload.js
+++ b/preload.js
@@ -1,3 +1,5 @@
+const { ipcRenderer } = require('electron');
+
 let hideCursorTimeout;
 
 function resetCursorTimeout() {
@@ -10,10 +12,26 @@ function resetCursorTimeout() {
   }, 5000);
 }
 
+function reportPad(pad) {
+  if (pad && pad.id) {
+    ipcRenderer.send('gamepad-connected', { id: pad.id, index: pad.index });
+  }
+}
+
+function scanPads() {
+  const pads = navigator.getGamepads ? navigator.getGamepads() : [];
+  for (const pad of pads) reportPad(pad);
+}
+
+window.addEventListener('gamepadconnected', e => reportPad(e.gamepad));
+
 window.addEventListener('mousemove', resetCursorTimeout);
 window.addEventListener('mousedown', resetCursorTimeout);
 window.addEventListener('keydown', resetCursorTimeout);
 
 window.addEventListener('DOMContentLoaded', () => {
   resetCursorTimeout();
+  scanPads();
 });
+
+setInterval(scanPads, 3000);

--- a/readme.MD
+++ b/readme.MD
@@ -57,6 +57,8 @@ To avoid xCloud's "click to continue" overlay when a quadrant loses OS focus, th
 
 Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, and choose a controller. Selecting a different controller reloads the quadrant so the previous stream is terminated. Profile selections persist across sessions. Press Ctrl+S in a focused quadrant to choose its audio output device directly within the stream.
 
+Controllers named "Xbox Controller" through "Xbox Controller 4" are automatically detected and routed to the matching quadrant.
+
 ## Notes
 
 - Works on Windows and Linux.


### PR DESCRIPTION
## Summary
- map Xbox controller names (1-4) to slots
- forward gamepad connections from preload to main
- auto-assign controllers on connection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a610b5193c8321a7bd2d53d3fc7ef7