### PR TITLE
Allow disabling quadrants from config panel

### DIFF
--- a/__tests__/profile-store.test.js
+++ b/__tests__/profile-store.test.js
@@ -40,4 +40,14 @@ describe('ProfileStore', () => {
     expect(store2.getAudio(0)).toBe('device-1');
   });
 
+  test('persists disabled state of quadrants', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'profiles-'));
+    const file = path.join(tmp, 'profiles.json');
+    const store1 = new ProfileStore(file);
+    store1.setDisabled(2, true);
+
+    const store2 = new ProfileStore(file);
+    expect(store2.isDisabled(2)).toBe(true);
+  });
+
 });

--- a/__tests__/register-shortcuts.test.js
+++ b/__tests__/register-shortcuts.test.js
@@ -59,3 +59,28 @@ test('registers shortcut to open audio selection dialog', () => {
   expect(webContents.getFocusedWebContents).toHaveBeenCalled();
   expect(executeJavaScript).toHaveBeenCalled();
 });
+
+test('focus shortcut uses latest view reference', () => {
+  const view1 = { webContents: { focus: jest.fn() } };
+  const views = [view1];
+  const toggleConfig = jest.fn();
+  const callbacks = {};
+
+  globalShortcut.register.mockClear();
+  globalShortcut.register.mockImplementation((accel, cb) => {
+    callbacks[accel] = cb;
+  });
+
+  registerShortcuts(views, toggleConfig);
+
+  // replace view after registration
+  const view2 = { webContents: { focus: jest.fn() } };
+  views[0] = view2;
+
+  // should focus the updated view without throwing if undefined
+  callbacks['CommandOrControl+Alt+1']();
+  expect(view2.webContents.focus).toHaveBeenCalled();
+
+  views[0] = null;
+  expect(() => callbacks['CommandOrControl+Alt+1']()).not.toThrow();
+});

--- a/assets/config.html
+++ b/assets/config.html
@@ -62,6 +62,11 @@
       <select id="controllerSelect"></select>
       <button id="applyController">Apply</button>
     </div>
+    <div class="row">
+      <label for="enabledChk">Quadrant enabled</label>
+      <input type="checkbox" id="enabledChk">
+      <button id="applyEnabled">Apply</button>
+    </div>
     <div style="text-align: right;">
       <button id="closeBtn">Close</button>
     </div>

--- a/assets/config.js
+++ b/assets/config.js
@@ -6,6 +6,7 @@ ipcRenderer.on('init', (_e, data) => {
   document.getElementById('profileName').value = data.name || '';
   fillProfiles(data.profiles, data.currentProfile);
   fillControllers(data.controllers, data.currentController);
+  document.getElementById('enabledChk').checked = data.enabled;
   enumerateAudio();
 });
 
@@ -49,6 +50,10 @@ document.getElementById('applyProfile').addEventListener('click', () => {
 
 document.getElementById('applyController').addEventListener('click', () => {
   ipcRenderer.send('select-controller', { index: viewIndex, controller: parseInt(document.getElementById('controllerSelect').value, 10) });
+});
+
+document.getElementById('applyEnabled').addEventListener('click', () => {
+  ipcRenderer.send('set-enabled', { index: viewIndex, enabled: document.getElementById('enabledChk').checked });
 });
 
 document.getElementById('newProfile').addEventListener('click', () => {

--- a/lib/profile-store.js
+++ b/lib/profile-store.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 class ProfileStore {
   constructor(file) {
     this.file = file;
-    this.data = { profiles: {}, assignments: [], controllers: [], audio: [] };
+    this.data = { profiles: {}, assignments: [], controllers: [], audio: [], disabled: [] };
     this.load();
   }
 
@@ -12,6 +12,7 @@ class ProfileStore {
       const txt = fs.readFileSync(this.file, 'utf8');
       this.data = JSON.parse(txt);
       if (!this.data.audio) this.data.audio = [];
+      if (!this.data.disabled) this.data.disabled = [];
     } catch {
       // keep defaults
     }
@@ -67,6 +68,15 @@ class ProfileStore {
 
   getAudio(slot) {
     return this.data.audio[slot];
+  }
+
+  setDisabled(slot, disabled) {
+    this.data.disabled[slot] = disabled;
+    this.save();
+  }
+
+  isDisabled(slot) {
+    return !!this.data.disabled[slot];
   }
 
 }

--- a/lib/register-shortcuts.js
+++ b/lib/register-shortcuts.js
@@ -86,14 +86,15 @@ function registerShortcuts(views, toggleConfig) {
     }
   });
 
-  views.forEach((view, i) => {
+  for (let i = 0; i < 4; i++) {
     globalShortcut.register(`CommandOrControl+${i + 1}`, () => {
       toggleConfig(i);
     });
     globalShortcut.register(`CommandOrControl+Alt+${i + 1}`, () => {
-      view.webContents.focus();
+      const view = views[i];
+      if (view) view.webContents.focus();
     });
-  });
+  }
 }
 
 module.exports = registerShortcuts;

--- a/readme.MD
+++ b/readme.MD
@@ -55,7 +55,7 @@ The app automatically splits the active display into four equal quadrants based 
 
 To avoid xCloud's "click to continue" overlay when a quadrant loses OS focus, the app spoofs focus in the main world of all `xbox.com` frames.
 
-Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, and choose a controller. Selecting a different controller reloads the quadrant so the previous stream is terminated. Profile selections persist across sessions. Press Ctrl+S in a focused quadrant to choose its audio output device directly within the stream.
+Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, choose a controller, and enable or disable the quadrant. Disabling removes the quadrant's browser view but the setting persists across sessions. You can still open the panel later to re‑enable the quadrant. Selecting a different controller reloads the quadrant so the previous stream is terminated. Profile selections persist across sessions. Press Ctrl+S in a focused quadrant to choose its audio output device directly within the stream.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- persist per-quadrant enabled state in profile store
- expose an enable checkbox in config panel and IPC to toggle views
- handle missing views in shortcut registrations and docs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a610fa7fec8321a94b2cd792617ad7