### PR TITLE
Remove automatic source pull and install dependencies on first run

### DIFF
--- a/quadcloud.bat
+++ b/quadcloud.bat
@@ -2,51 +2,25 @@
 setlocal
 cd /d %~dp0
 
-set REPO_URL=https://github.com/jerdaz/quadcloud
-set BRANCH=main
 set STATE_FILE=.update_state
 
 for /f %%A in ('powershell -NoProfile -Command "Get-Date -Format yyyy-MM-dd"') do set TODAY=%%A
 
 if exist "%STATE_FILE%" (
   set /p LAST_DATE=<"%STATE_FILE%"
-  for /f "skip=1 delims=" %%A in (%STATE_FILE%) do set LAST_COMMIT=%%A
 ) else (
   set LAST_DATE=
-  set LAST_COMMIT=
 )
 
 if not "%LAST_DATE%"=="%TODAY%" (
-  echo Checking for updates...
-  for /f %%A in ('powershell -NoProfile -Command "(Invoke-RestMethod https://api.github.com/repos/jerdaz/quadcloud/commits/%BRANCH%).sha"') do set REMOTE_COMMIT=%%A
-
-  echo Installing latest Electron...
+  echo Checking for Electron updates...
   call npm install electron@latest --save >nul
+  >"%STATE_FILE%" echo %TODAY%
+)
 
-  if not "%REMOTE_COMMIT%"=="%LAST_COMMIT%" (
-    echo Updating source...
-    set TMP_DIR=%TEMP%\quadcloud_update
-    if exist "%TMP_DIR%" rd /s /q "%TMP_DIR%"
-    mkdir "%TMP_DIR%"
-    curl -L "%REPO_URL%/archive/refs/heads/%BRANCH%.tar.gz" -o "%TMP_DIR%\update.tar.gz"
-    tar -xzf "%TMP_DIR%\update.tar.gz" -C "%TMP_DIR%" --strip-components=1 --exclude="*/node_modules/*"
-    xcopy "%TMP_DIR%\*" . /E /Y >nul
-    rd /s /q "%TMP_DIR%"
-
-    echo Installing dependencies...
-    call npm install >nul
-
-    set LAST_COMMIT=%REMOTE_COMMIT%
-  ) else (
-    echo Source is up to date.
-  )
-
-  >"%STATE_FILE%" (
-    echo %TODAY%
-    echo %LAST_COMMIT%
-  )
-) else (
-  echo Using cached build; no updates today.
+if not exist node_modules (
+  echo Installing dependencies...
+  call npm install >nul
 )
 
 echo Starting app...

--- a/readme.MD
+++ b/readme.MD
@@ -12,7 +12,7 @@ Electron app that splits the display into four isolated browser sessions for xCl
    powershell -Command "Invoke-WebRequest -Uri https://github.com/redphx/better-xcloud/releases/latest/download/better-xcloud.user.js -OutFile better-xcloud.user.js"
    ```
 
-4. **Start the app** – run `quadcloud.bat`. On the first launch of each day the script updates Electron and, when the main branch has new commits, refreshes the source and installs dependencies before starting the application.
+4. **Start the app** – run `quadcloud.bat`. The script installs dependencies on the first launch and updates Electron once per day before starting the application.
 
 ## Linux setup (Debian/Ubuntu)
 
@@ -37,7 +37,7 @@ Electron app that splits the display into four isolated browser sessions for xCl
    curl -L -o better-xcloud.user.js https://github.com/redphx/better-xcloud/releases/latest/download/better-xcloud.user.js
    ```
 
-4. Start the app (updates run only once per day):
+4. Start the app (Electron updates run once per day and dependencies install on first run):
 
    ```bash
    chmod +x start.sh
@@ -46,7 +46,7 @@ Electron app that splits the display into four isolated browser sessions for xCl
 ## Usage
 
 ```bash
-npm install
+npm install # first run only
 npm start
 ```
 

--- a/start.sh
+++ b/start.sh
@@ -2,45 +2,23 @@
 set -e
 cd "$(dirname "$0")"
 
-REPO_URL="https://github.com/jerdaz/quadcloud"
-BRANCH="main"
 STATE_FILE=".update_state"
 
 TODAY=$(date +%Y-%m-%d)
-
 LAST_DATE=""
-LAST_COMMIT=""
 if [ -f "$STATE_FILE" ]; then
-  LAST_DATE=$(sed -n '1p' "$STATE_FILE")
-  LAST_COMMIT=$(sed -n '2p' "$STATE_FILE")
+  LAST_DATE=$(cat "$STATE_FILE")
 fi
 
 if [ "$LAST_DATE" != "$TODAY" ]; then
-  echo "Checking for updates..."
-  REMOTE_COMMIT=$(curl -s "https://api.github.com/repos/jerdaz/quadcloud/commits/$BRANCH" | grep '"sha"' | head -n1 | cut -d '"' -f4)
-
-  echo "Installing latest Electron..."
+  echo "Checking for Electron updates..."
   npm install electron@latest --save > /dev/null
+  printf "%s\n" "$TODAY" > "$STATE_FILE"
+fi
 
-  if [ "$REMOTE_COMMIT" != "$LAST_COMMIT" ]; then
-    echo "Updating source..."
-    TMP_DIR=$(mktemp -d)
-    curl -Ls "$REPO_URL/archive/refs/heads/$BRANCH.tar.gz" -o "$TMP_DIR/update.tar.gz"
-    tar -xzf "$TMP_DIR/update.tar.gz" --strip-components=1 --exclude='*/node_modules/*' -C "$TMP_DIR"
-    cp -a "$TMP_DIR/." .
-    rm -rf "$TMP_DIR"
-
-    echo "Installing dependencies..."
-    npm install > /dev/null
-
-    LAST_COMMIT=$REMOTE_COMMIT
-  else
-    echo "Source is up to date."
-  fi
-
-  printf "%s\n%s\n" "$TODAY" "$LAST_COMMIT" > "$STATE_FILE"
-else
-  echo "Using cached build; no updates today."
+if [ ! -d node_modules ]; then
+  echo "Installing dependencies..."
+  npm install > /dev/null
 fi
 
 echo "Starting app..."


### PR DESCRIPTION
## Summary
- stop scripts from downloading latest source; keep daily Electron update
- install npm dependencies on first run only
- document new startup behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a61b7a38e483218d7cf26409bfa67f