### PR TITLE
Auto-preselect Xbox controller audio devices

### DIFF
--- a/__tests__/register-shortcuts.test.js
+++ b/__tests__/register-shortcuts.test.js
@@ -16,7 +16,7 @@ test('registers shortcut to open developer tools', () => {
     callbacks[accelerator] = cb;
   });
 
-  registerShortcuts(views, toggleConfig);
+  registerShortcuts(views, toggleConfig, () => 0);
 
   expect(globalShortcut.register).toHaveBeenCalledWith(
     'CommandOrControl+Alt+I',
@@ -33,9 +33,10 @@ test('registers shortcut to open developer tools', () => {
 });
 
 test('registers shortcut to open audio selection dialog', () => {
-  const views = [];
+  const views = [{}];
   const toggleConfig = jest.fn();
   const callbacks = {};
+  const getController = jest.fn().mockReturnValue(1);
 
   globalShortcut.register.mockClear();
   webContents.getFocusedWebContents.mockReset();
@@ -44,7 +45,7 @@ test('registers shortcut to open audio selection dialog', () => {
     callbacks[accelerator] = cb;
   });
 
-  registerShortcuts(views, toggleConfig);
+  registerShortcuts(views, toggleConfig, getController);
 
   expect(globalShortcut.register).toHaveBeenCalledWith(
     'CommandOrControl+S',
@@ -53,11 +54,10 @@ test('registers shortcut to open audio selection dialog', () => {
 
   const executeJavaScript = jest.fn();
   webContents.getFocusedWebContents.mockReturnValue({ executeJavaScript });
-
   callbacks['CommandOrControl+S']();
 
   expect(webContents.getFocusedWebContents).toHaveBeenCalled();
-  expect(executeJavaScript).toHaveBeenCalled();
+  expect(executeJavaScript).toHaveBeenCalledWith(expect.stringContaining('Xbox Controller 2'));
 });
 
 test('focus shortcut uses latest view reference', () => {
@@ -71,7 +71,7 @@ test('focus shortcut uses latest view reference', () => {
     callbacks[accel] = cb;
   });
 
-  registerShortcuts(views, toggleConfig);
+  registerShortcuts(views, toggleConfig, () => 0);
 
   // replace view after registration
   const view2 = { webContents: { focus: jest.fn() } };

--- a/lib/register-shortcuts.js
+++ b/lib/register-shortcuts.js
@@ -1,6 +1,7 @@
 const { app, globalShortcut, webContents } = require('electron');
 
-const AUDIO_DIALOG_JS = `
+function audioDialogJS(targetLabel) {
+  return `
 (() => {
   const existing = document.getElementById('qc-audio-dialog');
   if (existing) { existing.remove(); return; }
@@ -45,6 +46,9 @@ const AUDIO_DIALOG_JS = `
       const opt = document.createElement('option');
       opt.value = d.deviceId;
       opt.textContent = d.label || 'Device';
+      if (d.label && d.label.includes('${targetLabel}')) {
+        opt.selected = true;
+      }
       select.appendChild(opt);
     });
   });
@@ -66,8 +70,13 @@ const AUDIO_DIALOG_JS = `
   cancel.addEventListener('click', () => overlay.remove());
 })();
 `;
+}
 
-function registerShortcuts(views, toggleConfig) {
+function controllerLabel(controller) {
+  return controller === 0 ? 'Xbox Controller' : `Xbox Controller ${controller + 1}`;
+}
+
+function registerShortcuts(views, toggleConfig, getController) {
   globalShortcut.register('CommandOrControl+Q', () => {
     app.quit();
   });
@@ -82,7 +91,10 @@ function registerShortcuts(views, toggleConfig) {
   globalShortcut.register('CommandOrControl+S', () => {
     const wc = webContents.getFocusedWebContents();
     if (wc) {
-      try { wc.executeJavaScript(AUDIO_DIALOG_JS); } catch {}
+      const index = views.findIndex(v => v && v.webContents === wc);
+      const controller = typeof getController === 'function' ? getController(index) : null;
+      const label = controller != null ? controllerLabel(controller) : '';
+      try { wc.executeJavaScript(audioDialogJS(label)); } catch {}
     }
   });
 

--- a/main.js
+++ b/main.js
@@ -413,7 +413,7 @@ ipcMain.on('close-config', (_e, { index }) => {
 app.whenReady().then(() => {
   profileStore = new ProfileStore(path.join(app.getPath('userData'), 'profiles.json'));
   createWindow();
-  registerShortcuts(views, toggleConfig);
+  registerShortcuts(views, toggleConfig, index => controllerAssignments[index]);
 });
 
 app.on('will-quit', () => {

--- a/readme.MD
+++ b/readme.MD
@@ -55,7 +55,7 @@ The app automatically splits the active display into four equal quadrants based 
 
 To avoid xCloud's "click to continue" overlay when a quadrant loses OS focus, the app spoofs focus in the main world of all `xbox.com` frames.
 
-Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, choose a controller, and enable or disable the quadrant. Disabling removes the quadrant's browser view but the setting persists across sessions. You can still open the panel later to re‑enable the quadrant. Selecting a different controller reloads the quadrant so the previous stream is terminated. Profile selections persist across sessions. Press Ctrl+S in a focused quadrant to choose its audio output device directly within the stream.
+Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, choose a controller, and enable or disable the quadrant. Disabling removes the quadrant's browser view but the setting persists across sessions. You can still open the panel later to re‑enable the quadrant. Selecting a different controller reloads the quadrant so the previous stream is terminated. Profile selections persist across sessions. Press Ctrl+S in a focused quadrant to choose its audio output device directly within the stream; when a headset is plugged into an Xbox controller, the matching "Xbox Controller" device is preselected automatically.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Auto-select the headset audio device associated with the active Xbox controller when opening the audio dialog
- Wire controller assignments into shortcut registration
- Document automatic controller headset detection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a61cffbdd88321ac57ffb3c9a42142