### PR TITLE
Silence Ctrl+A audio device application

### DIFF
--- a/__tests__/register-shortcuts.test.js
+++ b/__tests__/register-shortcuts.test.js
@@ -83,9 +83,13 @@ test('registers shortcut to auto-apply audio selection for all quadrants', () =>
 
   callbacks['CommandOrControl+A']();
 
-  expect(view1.webContents.executeJavaScript).toHaveBeenCalledWith(expect.stringContaining('Xbox Controller'));
-  expect(view2.webContents.executeJavaScript).toHaveBeenCalledWith(expect.stringContaining('Xbox Controller 2'));
-  expect(view1.webContents.executeJavaScript).toHaveBeenCalledWith(expect.stringContaining('apply.click'));
+  const script1 = view1.webContents.executeJavaScript.mock.calls[0][0];
+  const script2 = view2.webContents.executeJavaScript.mock.calls[0][0];
+  expect(script1).toContain('Xbox Controller');
+  expect(script1).toContain('enumerateDevices');
+  expect(script1).not.toContain('qc-audio-dialog');
+  expect(script2).toContain('Xbox Controller 2');
+  expect(script2).not.toContain('qc-audio-dialog');
 });
 
 test('focus shortcut uses latest view reference', () => {

--- a/lib/register-shortcuts.js
+++ b/lib/register-shortcuts.js
@@ -1,6 +1,27 @@
 const { app, globalShortcut, webContents } = require('electron');
 
 function audioDialogJS(targetLabel, autoApply) {
+  if (autoApply) {
+    return `
+(() => {
+  navigator.mediaDevices.enumerateDevices().then(async devs => {
+    const outputs = devs.filter(d => d.kind === 'audiooutput');
+    const match = outputs.find(d => d.label && d.label.includes('${targetLabel}'));
+    const id = match ? match.deviceId : (outputs[0] ? outputs[0].deviceId : null);
+    if (!id) return;
+    if (navigator.mediaDevices && navigator.mediaDevices.selectAudioOutput) {
+      try { await navigator.mediaDevices.selectAudioOutput({ deviceId: id }); } catch {}
+    }
+    const els = document.querySelectorAll('audio, video');
+    for (const el of els) {
+      if (typeof el.setSinkId === 'function') {
+        try { await el.setSinkId(id); } catch {}
+      }
+    }
+  });
+})();
+`;
+  }
   return `
 (() => {
   const existing = document.getElementById('qc-audio-dialog');
@@ -51,9 +72,6 @@ function audioDialogJS(targetLabel, autoApply) {
       }
       select.appendChild(opt);
     });
-    if (${autoApply ? 'true' : 'false'}) {
-      apply.click();
-    }
   });
 
   apply.addEventListener('click', async () => {

--- a/readme.MD
+++ b/readme.MD
@@ -53,7 +53,7 @@ npm start
 
 The app automatically splits the active display into four equal quadrants based on the screen resolution. Each quadrant loads `https://xbox.com/play` by default, and you can point them to other streaming services if needed.
 
-Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, choose a controller, and enable or disable the quadrant. Disabling removes the quadrant's browser view but the setting persists across sessions. You can still open the panel later to re‑enable the quadrant. Selecting a different controller reloads the quadrant so the previous stream is terminated. Profile selections persist across sessions. Press Ctrl+S in a focused quadrant to choose its audio output device directly within the stream; when a headset is plugged into an Xbox controller, the matching "Xbox Controller" device is preselected automatically. Press Ctrl+A at any time to automatically reopen the selection dialog in all quadrants and apply the preselected device—useful after plugging or unplugging a headset.
+Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, choose a controller, and enable or disable the quadrant. Disabling removes the quadrant's browser view but the setting persists across sessions. You can still open the panel later to re‑enable the quadrant. Selecting a different controller reloads the quadrant so the previous stream is terminated. Profile selections persist across sessions. Press Ctrl+S in a focused quadrant to choose its audio output device directly within the stream; when a headset is plugged into an Xbox controller, the matching "Xbox Controller" device is preselected automatically. Press Ctrl+A at any time to silently apply the preselected device in all quadrants—useful after plugging or unplugging a headset without reopening the dialog.
 
 ## Notes
 
@@ -73,7 +73,7 @@ Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or
 - **Ctrl+Alt+4**: focus the bottom-right quadrant.
 - **Ctrl+Alt+I**: open developer tools for the focused view.
 - **Ctrl+S**: open the speaker selection dialog for the focused quadrant.
-- **Ctrl+A**: automatically apply the preferred audio device for all quadrants.
+- **Ctrl+A**: automatically apply the preferred audio device for all quadrants without showing a dialog.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- apply controller audio selection in the background when pressing Ctrl+A
- update tests and docs for silent Ctrl+A behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6336b6578832199426a870905f012