### PR TITLE
Avoid WebContents MaxListeners warnings

### DIFF
--- a/__tests__/set-max-listeners.test.js
+++ b/__tests__/set-max-listeners.test.js
@@ -1,0 +1,12 @@
+const setMaxListeners = require('../lib/set-max-listeners');
+
+test('sets max listeners on emitter', () => {
+  const emitter = { setMaxListeners: jest.fn() };
+  setMaxListeners(emitter, 42);
+  expect(emitter.setMaxListeners).toHaveBeenCalledWith(42);
+});
+
+test('handles missing setMaxListeners gracefully', () => {
+  const emitter = {};
+  expect(() => setMaxListeners(emitter, 10)).not.toThrow();
+});

--- a/lib/set-max-listeners.js
+++ b/lib/set-max-listeners.js
@@ -1,0 +1,10 @@
+const DEFAULT_MAX_LISTENERS = 30;
+
+function setMaxListeners(emitter, max = DEFAULT_MAX_LISTENERS) {
+  if (emitter && typeof emitter.setMaxListeners === 'function') {
+    emitter.setMaxListeners(max);
+  }
+}
+
+module.exports = setMaxListeners;
+module.exports.DEFAULT_MAX_LISTENERS = DEFAULT_MAX_LISTENERS;

--- a/main.js
+++ b/main.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const { XBOX_HOST_RE, getGamepadPatch } = require('./lib/xcloud');
 const ProfileStore = require('./lib/profile-store');
 const { destroyView, closeConfigView } = require('./lib/view-utils');
+const setMaxListeners = require('./lib/set-max-listeners');
 
 app.commandLine.appendSwitch('disable-background-timer-throttling');
 app.commandLine.appendSwitch('disable-renderer-backgrounding');
@@ -230,6 +231,7 @@ function createView(x, y, width, height, slot, profileId, controllerIndex) {
       preload: path.join(__dirname, 'preload.js')
     }
   });
+  setMaxListeners(view.webContents);
   view.webContents.controllerIndex = controllerIndex;
   view.setBounds({ x, y, width, height });
   view.setAutoResize({ width: true, height: true });
@@ -290,15 +292,16 @@ positions.forEach((pos, i) => {
 function getConfigView(index) {
   let cfg = configViews[index];
   if (cfg) return cfg;
-  cfg = new BrowserView({
-    webPreferences: { nodeIntegration: true, contextIsolation: false }
-  });
-  cfg.setBounds({ x: positions[index].x, y: positions[index].y, width: viewWidth, height: viewHeight });
-  cfg.setAutoResize({ width: true, height: true });
-  cfg.webContents.loadFile(path.join(__dirname, 'assets', 'config.html'));
-  configViews[index] = cfg;
-  return cfg;
-}
+    cfg = new BrowserView({
+      webPreferences: { nodeIntegration: true, contextIsolation: false }
+    });
+    setMaxListeners(cfg.webContents);
+    cfg.setBounds({ x: positions[index].x, y: positions[index].y, width: viewWidth, height: viewHeight });
+    cfg.setAutoResize({ width: true, height: true });
+    cfg.webContents.loadFile(path.join(__dirname, 'assets', 'config.html'));
+    configViews[index] = cfg;
+    return cfg;
+  }
 
 function gatherConfigData(index) {
   const profileId = profileStore.getAssignment(index);


### PR DESCRIPTION
## Summary
- Allow each BrowserView's webContents to handle more than 10 listeners to prevent MaxListenersExceeded warnings
- Added helper `setMaxListeners` and applied it to main and config views
- Introduced unit tests covering the helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6362cdefc832195196b2ce73ec3bd