### PR TITLE
Auto-apply audio device to new video elements

### DIFF
--- a/__tests__/register-shortcuts.test.js
+++ b/__tests__/register-shortcuts.test.js
@@ -87,6 +87,8 @@ test('registers shortcut to auto-apply audio selection for all quadrants', () =>
   const script2 = view2.webContents.executeJavaScript.mock.calls[0][0];
   expect(script1).toContain('Xbox Controller');
   expect(script1).toContain('enumerateDevices');
+  expect(script1).toContain('MutationObserver');
+  expect(script1).toContain("addEventListener('play'");
   expect(script1).not.toContain('qc-audio-dialog');
   expect(script2).toContain('Xbox Controller 2');
   expect(script2).not.toContain('qc-audio-dialog');

--- a/lib/register-shortcuts.js
+++ b/lib/register-shortcuts.js
@@ -12,12 +12,25 @@ function audioDialogJS(targetLabel, autoApply) {
     if (navigator.mediaDevices && navigator.mediaDevices.selectAudioOutput) {
       try { await navigator.mediaDevices.selectAudioOutput({ deviceId: id }); } catch {}
     }
-    const els = document.querySelectorAll('audio, video');
-    for (const el of els) {
+    const apply = async el => {
       if (typeof el.setSinkId === 'function') {
         try { await el.setSinkId(id); } catch {}
       }
-    }
+    };
+    const handle = el => {
+      apply(el);
+      el.addEventListener('play', () => apply(el), { once: true });
+    };
+    document.querySelectorAll('audio, video').forEach(handle);
+    new MutationObserver(muts => {
+      muts.forEach(m => m.addedNodes.forEach(n => {
+        if (n.tagName === 'VIDEO' || n.tagName === 'AUDIO') {
+          handle(n);
+        } else if (n.querySelectorAll) {
+          n.querySelectorAll('audio, video').forEach(handle);
+        }
+      }));
+    }).observe(document.body, { childList: true, subtree: true });
   });
 })();
 `;

--- a/readme.MD
+++ b/readme.MD
@@ -53,7 +53,7 @@ npm start
 
 The app automatically splits the active display into four equal quadrants based on the screen resolution. Each quadrant loads `https://xbox.com/play` by default, and you can point them to other streaming services if needed.
 
-Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, choose a controller, and enable or disable the quadrant. Disabling removes the quadrant's browser view but the setting persists across sessions. You can still open the panel later to re‑enable the quadrant. Selecting a different controller reloads the quadrant so the previous stream is terminated. Profile selections persist across sessions. Press Ctrl+S in a focused quadrant to choose its audio output device directly within the stream; when a headset is plugged into an Xbox controller, the matching "Xbox Controller" device is preselected automatically. Press Ctrl+A at any time to silently apply the preselected device in all quadrants—useful after plugging or unplugging a headset without reopening the dialog.
+Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, choose a controller, and enable or disable the quadrant. Disabling removes the quadrant's browser view but the setting persists across sessions. You can still open the panel later to re‑enable the quadrant. Selecting a different controller reloads the quadrant so the previous stream is terminated. Profile selections persist across sessions. Press Ctrl+S in a focused quadrant to choose its audio output device directly within the stream; when a headset is plugged into an Xbox controller, the matching "Xbox Controller" device is preselected automatically. Press Ctrl+A at any time to silently apply the preselected device in all quadrants—useful after plugging or unplugging a headset without reopening the dialog. New video elements that start playing automatically use the selected device.
 
 ## Notes
 
@@ -73,7 +73,7 @@ Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or
 - **Ctrl+Alt+4**: focus the bottom-right quadrant.
 - **Ctrl+Alt+I**: open developer tools for the focused view.
 - **Ctrl+S**: open the speaker selection dialog for the focused quadrant.
-- **Ctrl+A**: automatically apply the preferred audio device for all quadrants without showing a dialog.
+- **Ctrl+A**: automatically apply the preferred audio device for all quadrants without showing a dialog; future video elements will use the selected device.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- ensure audio device selection is applied to newly created media elements
- watch for future videos when applying audio output or using Ctrl+A
- document automatic handling and extend tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a63670c1c08321bbde41350e5dc813