### PR TITLE
Auto-apply audio sink to new video elements

### DIFF
--- a/__tests__/register-shortcuts.test.js
+++ b/__tests__/register-shortcuts.test.js
@@ -87,6 +87,8 @@ test('registers shortcut to auto-apply audio selection for all quadrants', () =>
   const script2 = view2.webContents.executeJavaScript.mock.calls[0][0];
   expect(script1).toContain('Xbox Controller');
   expect(script1).toContain('enumerateDevices');
+  expect(script1).toContain('MutationObserver');
+  expect(script1).toContain("addEventListener('play'");
   expect(script1).not.toContain('qc-audio-dialog');
   expect(script2).toContain('Xbox Controller 2');
   expect(script2).not.toContain('qc-audio-dialog');

--- a/lib/register-shortcuts.js
+++ b/lib/register-shortcuts.js
@@ -9,15 +9,31 @@ function audioDialogJS(targetLabel, autoApply) {
     const match = outputs.find(d => d.label && d.label.includes('${targetLabel}'));
     const id = match ? match.deviceId : (outputs[0] ? outputs[0].deviceId : null);
     if (!id) return;
-    if (navigator.mediaDevices && navigator.mediaDevices.selectAudioOutput) {
-      try { await navigator.mediaDevices.selectAudioOutput({ deviceId: id }); } catch {}
-    }
-    const els = document.querySelectorAll('audio, video');
-    for (const el of els) {
+    const apply = async el => {
       if (typeof el.setSinkId === 'function') {
         try { await el.setSinkId(id); } catch {}
       }
+    };
+    if (navigator.mediaDevices && navigator.mediaDevices.selectAudioOutput) {
+      try { await navigator.mediaDevices.selectAudioOutput({ deviceId: id }); } catch {}
     }
+    const handle = el => {
+      apply(el);
+      el.addEventListener('play', () => apply(el), { once: true });
+    };
+    document.querySelectorAll('audio, video').forEach(handle);
+    const mo = new MutationObserver(muts => {
+      for (const m of muts) {
+        for (const node of m.addedNodes) {
+          if (node.tagName === 'AUDIO' || node.tagName === 'VIDEO') {
+            handle(node);
+          } else if (node.querySelectorAll) {
+            node.querySelectorAll('audio, video').forEach(handle);
+          }
+        }
+      }
+    });
+    mo.observe(document.documentElement, { childList: true, subtree: true });
   });
 })();
 `;

--- a/readme.MD
+++ b/readme.MD
@@ -73,8 +73,7 @@ Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or
 - **Ctrl+Alt+4**: focus the bottom-right quadrant.
 - **Ctrl+Alt+I**: open developer tools for the focused view.
 - **Ctrl+S**: open the speaker selection dialog for the focused quadrant.
-- **Ctrl+A**: automatically apply the preferred audio device for all quadrants without showing a dialog.
-
+- **Ctrl+A**: automatically apply the preferred audio device for all quadrants without showing a dialog. Newly created video elements will also receive the selection when playback begins.
 ## Testing
 
 ```bash


### PR DESCRIPTION
## Summary
- Ensure automatic audio device selection applies to new media elements by monitoring DOM mutations and play events
- Verify automatic audio handling via updated tests
- Clarify README to note audio selection persists for newly created videos

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a63670c1c08321bbde41350e5dc813