### PR TITLE
Ensure controller navigation is active in all quadrants

### DIFF
--- a/main.js
+++ b/main.js
@@ -84,10 +84,6 @@ const XFOCUS_PATCH = `
 
 function injectPatchIntoFrame(frame) {
   try {
-    const url = frame.url || '';
-    let host = '';
-    try { host = new URL(url).hostname; } catch {}
-    if (!host || !XBOX_HOST_RE.test(host)) return;
     return frame.executeJavaScript(XFOCUS_PATCH, true);
   } catch {
     // ignore

--- a/readme.MD
+++ b/readme.MD
@@ -1,6 +1,6 @@
 # Quad Play
 
-Electron app that splits the display into four isolated browser sessions for xCloud or Remote Play. Each view scales to half of the screen's width and height—for example, on a 4K screen each view is 1080p, and on a 1080p screen each view is 540p. Every view uses its own persistent profile and only listens to a single controller.
+Electron app that splits the display into four isolated browser sessions for xCloud or Remote Play. Each view scales to half of the screen's width and height—for example, on a 4K screen each view is 1080p, and on a 1080p screen each view is 540p. Every view uses its own persistent profile and only listens to a single controller. Controller navigation overlays remain visible in all quadrants even when they're not the active window.
 
 ## Windows setup
 


### PR DESCRIPTION
## Summary
- Inject focus spoof script into every frame to keep controller navigation overlays visible in background quadrants
- Document that controller navigation stays visible even when a quadrant is not the active window

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a63723efdc8321a2b8d960093af0ae