### PR TITLE
fix ctrl-a audio device selection

### DIFF
--- a/__tests__/register-shortcuts.test.js
+++ b/__tests__/register-shortcuts.test.js
@@ -61,8 +61,8 @@ test('registers shortcut to open audio selection dialog', () => {
 });
 
 test('registers shortcut to auto-apply audio selection for all quadrants', () => {
-  const view1 = { webContents: { executeJavaScript: jest.fn() } };
-  const view2 = { webContents: { executeJavaScript: jest.fn() } };
+  const view1 = { webContents: { executeJavaScript: jest.fn(), controllerIndex: 0 } };
+  const view2 = { webContents: { executeJavaScript: jest.fn(), controllerIndex: 1 } };
   const views = [view1, view2];
   const toggleConfig = jest.fn();
   const callbacks = {};

--- a/lib/register-shortcuts.js
+++ b/lib/register-shortcuts.js
@@ -120,9 +120,9 @@ function registerShortcuts(views, toggleConfig, getController) {
   });
 
   globalShortcut.register('CommandOrControl+A', () => {
-    views.forEach((view, i) => {
+    views.forEach(view => {
       if (view && view.webContents) {
-        const controller = typeof getController === 'function' ? getController(i) : null;
+        const controller = view.webContents.controllerIndex;
         const label = controller != null ? controllerLabel(controller) : '';
         try { view.webContents.executeJavaScript(audioDialogJS(label, true)); } catch {}
       }


### PR DESCRIPTION
## Summary
- ensure Ctrl+A uses each view's assigned controller when auto-selecting audio
- adjust tests for new controller lookup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a639f46f508321bc5d1d79d8650498