### PR TITLE
Hide Ctrl+A audio dialog

### DIFF
--- a/__tests__/register-shortcuts.test.js
+++ b/__tests__/register-shortcuts.test.js
@@ -86,10 +86,10 @@ test('registers shortcut to auto-confirm audio dialog for all quadrants', () => 
   const script1 = view1.webContents.executeJavaScript.mock.calls[0][0];
   const script2 = view2.webContents.executeJavaScript.mock.calls[0][0];
   expect(script1).toContain('Xbox Controller');
-  expect(script1).toContain('qc-audio-dialog');
-  expect(script1).toContain('apply.click');
+  expect(script1).toContain('enumerateDevices');
+  expect(script1).not.toContain('qc-audio-dialog');
   expect(script2).toContain('Xbox Controller 2');
-  expect(script2).toContain('apply.click');
+  expect(script2).not.toContain('qc-audio-dialog');
 });
 
 test('focus shortcut uses latest view reference', () => {

--- a/lib/register-shortcuts.js
+++ b/lib/register-shortcuts.js
@@ -1,6 +1,27 @@
 const { app, globalShortcut, webContents } = require('electron');
 
 function audioDialogJS(targetLabel, autoApply) {
+  if (autoApply) {
+    return `
+(() => {
+  navigator.mediaDevices.enumerateDevices().then(async devs => {
+    const match = devs.find(d => d.kind === 'audiooutput' && d.label && d.label.includes('${targetLabel}')) ||
+      devs.find(d => d.kind === 'audiooutput');
+    if (!match) return;
+    const id = match.deviceId;
+    if (navigator.mediaDevices && navigator.mediaDevices.selectAudioOutput) {
+      try { await navigator.mediaDevices.selectAudioOutput({ deviceId: id }); } catch {}
+    }
+    const els = document.querySelectorAll('audio, video');
+    for (const el of els) {
+      if (typeof el.setSinkId === 'function') {
+        try { await el.setSinkId(id); } catch {}
+      }
+    }
+  });
+})();
+`;
+  }
   return `
 (() => {
   const existing = document.getElementById('qc-audio-dialog');
@@ -51,7 +72,6 @@ function audioDialogJS(targetLabel, autoApply) {
       }
       select.appendChild(opt);
     });
-    ${autoApply ? 'apply.click();' : ''}
   });
 
   apply.addEventListener('click', async () => {

--- a/readme.MD
+++ b/readme.MD
@@ -53,7 +53,7 @@ npm start
 
 The app automatically splits the active display into four equal quadrants based on the screen resolution. Each quadrant loads `https://xbox.com/play` by default, and you can point them to other streaming services if needed.
 
-Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, choose a controller, and enable or disable the quadrant. Disabling removes the quadrant's browser view but the setting persists across sessions. You can still open the panel later to re‑enable the quadrant. Selecting a different controller reloads the quadrant so the previous stream is terminated. Profile selections persist across sessions. Press Ctrl+S in a focused quadrant to choose its audio output device directly within the stream; when a headset is plugged into an Xbox controller, the matching "Xbox Controller" device is preselected automatically. Press Ctrl+A to run that same dialog for every quadrant and immediately apply the preselected device—useful after plugging or unplugging a headset without reopening each dialog manually.
+Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, choose a controller, and enable or disable the quadrant. Disabling removes the quadrant's browser view but the setting persists across sessions. You can still open the panel later to re‑enable the quadrant. Selecting a different controller reloads the quadrant so the previous stream is terminated. Profile selections persist across sessions. Press Ctrl+S in a focused quadrant to choose its audio output device directly within the stream; when a headset is plugged into an Xbox controller, the matching "Xbox Controller" device is preselected automatically. Press Ctrl+A to apply the preselected device to every quadrant without showing the dialog—useful after plugging or unplugging a headset without reopening each dialog manually.
 
 ## Notes
 
@@ -73,7 +73,7 @@ Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or
 - **Ctrl+Alt+4**: focus the bottom-right quadrant.
 - **Ctrl+Alt+I**: open developer tools for the focused view.
 - **Ctrl+S**: open the speaker selection dialog for the focused quadrant.
-- **Ctrl+A**: open and auto-confirm the speaker selection dialog for all quadrants.
+- **Ctrl+A**: apply the preselected speaker device for all quadrants without showing the dialog.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- make CommandOrControl+A silently apply audio output for each quadrant without rendering an overlay
- update Ctrl+A tests to expect headless behavior
- document that Ctrl+A now applies preselected speaker device without showing the dialog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a758204078832189b9999e77e7417d