### PR TITLE
Hide audio dialog for Ctrl+A

### DIFF
--- a/__tests__/register-shortcuts.test.js
+++ b/__tests__/register-shortcuts.test.js
@@ -58,6 +58,7 @@ test('registers shortcut to open audio selection dialog', () => {
 
   expect(webContents.getFocusedWebContents).toHaveBeenCalled();
   expect(executeJavaScript).toHaveBeenCalledWith(expect.stringContaining('Xbox Controller 2'));
+  expect(executeJavaScript.mock.calls[0][0]).toContain("overlay.style.display = 'flex'");
 });
 
 test('registers shortcut to auto-confirm audio dialog for all quadrants', () => {
@@ -87,8 +88,10 @@ test('registers shortcut to auto-confirm audio dialog for all quadrants', () => 
   const script2 = view2.webContents.executeJavaScript.mock.calls[0][0];
   expect(script1).toContain('Xbox Controller');
   expect(script1).toContain('qc-audio-dialog');
+  expect(script1).toContain("overlay.style.display = 'none'");
   expect(script1).toContain('apply.click');
   expect(script2).toContain('Xbox Controller 2');
+  expect(script2).toContain("overlay.style.display = 'none'");
   expect(script2).toContain('apply.click');
 });
 

--- a/lib/register-shortcuts.js
+++ b/lib/register-shortcuts.js
@@ -13,7 +13,7 @@ function audioDialogJS(targetLabel, autoApply) {
   overlay.style.right = '0';
   overlay.style.bottom = '0';
   overlay.style.background = 'rgba(0,0,0,0.6)';
-  overlay.style.display = 'flex';
+  overlay.style.display = '${autoApply ? 'none' : 'flex'}';
   overlay.style.alignItems = 'center';
   overlay.style.justifyContent = 'center';
   overlay.style.zIndex = '999999';

--- a/readme.MD
+++ b/readme.MD
@@ -53,7 +53,7 @@ npm start
 
 The app automatically splits the active display into four equal quadrants based on the screen resolution. Each quadrant loads `https://xbox.com/play` by default, and you can point them to other streaming services if needed.
 
-Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, choose a controller, and enable or disable the quadrant. Disabling removes the quadrant's browser view but the setting persists across sessions. You can still open the panel later to re‑enable the quadrant. Selecting a different controller reloads the quadrant so the previous stream is terminated. Profile selections persist across sessions. Press Ctrl+S in a focused quadrant to choose its audio output device directly within the stream; when a headset is plugged into an Xbox controller, the matching "Xbox Controller" device is preselected automatically. Press Ctrl+A to run that same dialog for every quadrant and immediately apply the preselected device—useful after plugging or unplugging a headset without reopening each dialog manually.
+Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, choose a controller, and enable or disable the quadrant. Disabling removes the quadrant's browser view but the setting persists across sessions. You can still open the panel later to re‑enable the quadrant. Selecting a different controller reloads the quadrant so the previous stream is terminated. Profile selections persist across sessions. Press Ctrl+S in a focused quadrant to choose its audio output device directly within the stream; when a headset is plugged into an Xbox controller, the matching "Xbox Controller" device is preselected automatically. Press Ctrl+A to apply the preselected device for every quadrant without displaying the dialog—useful after plugging or unplugging a headset without reopening each dialog manually.
 
 ## Notes
 
@@ -73,7 +73,7 @@ Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or
 - **Ctrl+Alt+4**: focus the bottom-right quadrant.
 - **Ctrl+Alt+I**: open developer tools for the focused view.
 - **Ctrl+S**: open the speaker selection dialog for the focused quadrant.
-- **Ctrl+A**: open and auto-confirm the speaker selection dialog for all quadrants.
+- **Ctrl+A**: apply the preselected speaker device for all quadrants without showing the dialog.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- Hide audio selection overlay when using Ctrl+A so device switching happens silently.
- Test visibility behavior for Ctrl+S and Ctrl+A shortcuts.
- Document that Ctrl+A applies the preselected audio device without showing a dialog.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a758204078832189b9999e77e7417d