### PR TITLE
Auto-apply audio device on change

### DIFF
--- a/__tests__/preload.test.js
+++ b/__tests__/preload.test.js
@@ -1,0 +1,31 @@
+const deviceListeners = {};
+const windowListeners = {};
+
+global.navigator = {
+  mediaDevices: {
+    addEventListener: jest.fn((event, cb) => {
+      deviceListeners[event] = cb;
+    })
+  }
+};
+
+global.window = {
+  addEventListener: jest.fn((event, cb) => {
+    windowListeners[event] = cb;
+  })
+};
+
+global.document = { body: { style: {} } };
+
+jest.mock('electron', () => ({
+  ipcRenderer: { send: jest.fn() }
+}));
+
+require('../preload.js');
+
+test('notifies main process when audio devices change', () => {
+  expect(navigator.mediaDevices.addEventListener).toHaveBeenCalledWith('devicechange', expect.any(Function));
+  const { ipcRenderer } = require('electron');
+  deviceListeners.devicechange();
+  expect(ipcRenderer.send).toHaveBeenCalledWith('audio-devices-changed');
+});

--- a/__tests__/register-shortcuts.test.js
+++ b/__tests__/register-shortcuts.test.js
@@ -6,6 +6,7 @@ jest.mock('electron', () => ({
 
 const registerShortcuts = require('../lib/register-shortcuts');
 const { globalShortcut, webContents } = require('electron');
+const { applyAudioAll } = require('../lib/register-shortcuts');
 
 test('registers shortcut to open developer tools', () => {
   const views = [];
@@ -93,6 +94,19 @@ test('registers shortcut to auto-confirm audio dialog for all quadrants', () => 
   expect(script2).toContain('Xbox Controller 2');
   expect(script2).toContain("overlay.style.display = 'none'");
   expect(script2).toContain('apply.click');
+});
+
+test('applyAudioAll applies audio selection across views', () => {
+  const view1 = { webContents: { executeJavaScript: jest.fn() } };
+  const view2 = { webContents: { executeJavaScript: jest.fn() } };
+  const getController = jest.fn().mockImplementation(i => i);
+
+  applyAudioAll([view1, view2], getController);
+
+  expect(view1.webContents.executeJavaScript).toHaveBeenCalled();
+  expect(view2.webContents.executeJavaScript).toHaveBeenCalled();
+  const script = view1.webContents.executeJavaScript.mock.calls[0][0];
+  expect(script).toContain("overlay.style.display = 'none'");
 });
 
 test('focus shortcut uses latest view reference', () => {

--- a/lib/register-shortcuts.js
+++ b/lib/register-shortcuts.js
@@ -77,6 +77,16 @@ function controllerLabel(controller) {
   return controller === 0 ? 'Xbox Controller' : `Xbox Controller ${controller + 1}`;
 }
 
+function applyAudioAll(views, getController) {
+  views.forEach((view, i) => {
+    if (view && view.webContents) {
+      const controller = typeof getController === 'function' ? getController(i) : null;
+      const label = controller != null ? controllerLabel(controller) : '';
+      try { view.webContents.executeJavaScript(audioDialogJS(label, true)); } catch {}
+    }
+  });
+}
+
 function registerShortcuts(views, toggleConfig, getController) {
   globalShortcut.register('CommandOrControl+Q', () => {
     app.quit();
@@ -100,13 +110,7 @@ function registerShortcuts(views, toggleConfig, getController) {
   });
 
   globalShortcut.register('CommandOrControl+A', () => {
-    views.forEach((view, i) => {
-      if (view && view.webContents) {
-        const controller = typeof getController === 'function' ? getController(i) : null;
-        const label = controller != null ? controllerLabel(controller) : '';
-        try { view.webContents.executeJavaScript(audioDialogJS(label, true)); } catch {}
-      }
-    });
+    applyAudioAll(views, getController);
   });
 
   for (let i = 0; i < 4; i++) {
@@ -122,3 +126,4 @@ function registerShortcuts(views, toggleConfig, getController) {
 
 module.exports = registerShortcuts;
 module.exports.audioDialogJS = audioDialogJS;
+module.exports.applyAudioAll = applyAudioAll;

--- a/main.js
+++ b/main.js
@@ -1,5 +1,7 @@
 const { app, BrowserWindow, BrowserView, session, screen, globalShortcut, ipcMain } = require('electron');
-const registerShortcuts = require('./lib/register-shortcuts');
+const shortcuts = require('./lib/register-shortcuts');
+const registerShortcuts = shortcuts;
+const { applyAudioAll } = shortcuts;
 const path = require('path');
 const fs = require('fs');
 const { XBOX_HOST_RE, getGamepadPatch } = require('./lib/xcloud');
@@ -396,6 +398,10 @@ ipcMain.on('select-audio', (_e, { index, deviceId }) => {
   profileStore.assignAudio(index, deviceId);
   closeConfigView(win, configViews, index);
   applyAudioOutput(index, deviceId);
+});
+
+ipcMain.on('audio-devices-changed', () => {
+  applyAudioAll(views, i => controllerAssignments[i]);
 });
 
 ipcMain.on('set-enabled', (_e, { index, enabled }) => {

--- a/preload.js
+++ b/preload.js
@@ -1,3 +1,5 @@
+const { ipcRenderer } = require('electron');
+
 let hideCursorTimeout;
 
 function resetCursorTimeout() {
@@ -8,6 +10,12 @@ function resetCursorTimeout() {
   hideCursorTimeout = setTimeout(() => {
     body.style.cursor = 'none';
   }, 5000);
+}
+
+if (navigator.mediaDevices && navigator.mediaDevices.addEventListener) {
+  navigator.mediaDevices.addEventListener('devicechange', () => {
+    ipcRenderer.send('audio-devices-changed');
+  });
 }
 
 window.addEventListener('mousemove', resetCursorTimeout);

--- a/readme.MD
+++ b/readme.MD
@@ -53,7 +53,7 @@ npm start
 
 The app automatically splits the active display into four equal quadrants based on the screen resolution. Each quadrant loads `https://xbox.com/play` by default, and you can point them to other streaming services if needed.
 
-Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, choose a controller, and enable or disable the quadrant. Disabling removes the quadrant's browser view but the setting persists across sessions. You can still open the panel later to re‑enable the quadrant. Selecting a different controller reloads the quadrant so the previous stream is terminated. Profile selections persist across sessions. Press Ctrl+S in a focused quadrant to choose its audio output device directly within the stream; when a headset is plugged into an Xbox controller, the matching "Xbox Controller" device is preselected automatically. Press Ctrl+A to apply the preselected device for every quadrant without displaying the dialog—useful after plugging or unplugging a headset without reopening each dialog manually.
+Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or switch profiles, create additional profiles beyond the default four, choose a controller, and enable or disable the quadrant. Disabling removes the quadrant's browser view but the setting persists across sessions. You can still open the panel later to re‑enable the quadrant. Selecting a different controller reloads the quadrant so the previous stream is terminated. Profile selections persist across sessions. Press Ctrl+S in a focused quadrant to choose its audio output device directly within the stream; when a headset is plugged into an Xbox controller, the matching "Xbox Controller" device is preselected automatically. Press Ctrl+A to apply the preselected device for every quadrant without displaying the dialog—useful after plugging or unplugging a headset without reopening each dialog manually. The same action runs automatically whenever the system's audio devices change.
 
 ## Notes
 
@@ -73,7 +73,7 @@ Each quadrant exposes a configuration panel (Ctrl+1–4) where you can rename or
 - **Ctrl+Alt+4**: focus the bottom-right quadrant.
 - **Ctrl+Alt+I**: open developer tools for the focused view.
 - **Ctrl+S**: open the speaker selection dialog for the focused quadrant.
-- **Ctrl+A**: apply the preselected speaker device for all quadrants without showing the dialog.
+- **Ctrl+A**: apply the preselected speaker device for all quadrants without showing the dialog (also triggered automatically on audio device changes).
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- auto-apply preselected audio device when system audio devices change
- expose helper to reuse Ctrl+A behavior and listen for device-change IPC
- document automatic audio device application

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a759fdf44883218b4eb8f49af977eb