### PR TITLE
Ensure xCloud views render focus outline

### DIFF
--- a/__tests__/xcloud.test.js
+++ b/__tests__/xcloud.test.js
@@ -1,4 +1,4 @@
-const { isXboxHost, getGamepadPatch } = require('../lib/xcloud');
+const { isXboxHost, getGamepadPatch, getFocusPatch } = require('../lib/xcloud');
 
 describe('isXboxHost', () => {
   test('matches xbox.com and subdomains', () => {
@@ -16,5 +16,13 @@ describe('getGamepadPatch', () => {
   test('includes provided controller index', () => {
     const patch = getGamepadPatch(2);
     expect(patch).toContain('const myIndex = 2;');
+  });
+});
+
+describe('getFocusPatch', () => {
+  test('spoofs focus-related properties', () => {
+    const patch = getFocusPatch();
+    expect(patch).toContain("document.dispatchEvent(new Event('focus'))");
+    expect(patch).toContain('visibilityState');
   });
 });

--- a/lib/xcloud.js
+++ b/lib/xcloud.js
@@ -32,7 +32,7 @@ function getGamepadPatch(index) {
   const filterEvent = ev => {
     if (ev.gamepad.index !== myIndex) {
       ev.stopImmediatePropagation();
-    } else {
+  } else {
       try { Object.defineProperty(ev.gamepad, 'index', { value: 0 }); } catch {}
     }
   };
@@ -51,8 +51,69 @@ function getGamepadPatch(index) {
 })()`;
 }
 
+function getFocusPatch() {
+  return `
+(() => {
+  if (window.__quadFocusSpoof) return;
+  window.__quadFocusSpoof = true;
+  const docProto = Document.prototype;
+  try { Object.defineProperty(docProto, 'hidden', { configurable: true, get(){ return false; } }); } catch {}
+  try { Object.defineProperty(docProto, 'webkitHidden', { configurable: true, get(){ return false; } }); } catch {}
+  try { Object.defineProperty(docProto, 'visibilityState', { configurable: true, get(){ return 'visible'; } }); } catch {}
+  try {
+    Object.defineProperty(docProto, 'hasFocus', {
+      configurable: true,
+      value: function(){ return true; }
+    });
+  } catch {}
+
+  const nativeAdd = EventTarget.prototype.addEventListener;
+  window.addEventListener = function(type, listener, opts){
+    if (type === 'blur' || type === 'visibilitychange') {
+      return nativeAdd.call(this, type, () => {}, opts);
+    }
+    return nativeAdd.call(this, type, listener, opts);
+  };
+
+  Document.prototype.addEventListener = function(type, listener, opts){
+    if (type === 'visibilitychange') {
+      return nativeAdd.call(this, type, () => {}, opts);
+    }
+    return nativeAdd.call(this, type, listener, opts);
+  };
+
+  const fireFocus = () => {
+    try { window.dispatchEvent(new Event('focus')); } catch {}
+    try { document.dispatchEvent(new Event('focus')); } catch {}
+  };
+  fireFocus();
+  setInterval(fireFocus, 4000);
+
+  const tryDismiss = () => {
+    const sel = 'button,[role=button],[data-testid*="activate" i],[aria-label*="activate" i],[aria-label*="focus" i]';
+    for (const el of document.querySelectorAll(sel)) {
+      const t = (el.innerText || el.textContent || '').toLowerCase();
+      if (/(click|klik).*here|hier|activate|activeren|focus/.test(t)) {
+        try { el.click(); return; } catch {}
+      }
+    }
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', tryDismiss, { once:true });
+  } else {
+    tryDismiss();
+  }
+
+  const tgt = document.documentElement || document.body;
+  if (tgt) new MutationObserver(tryDismiss).observe(tgt, { childList:true, subtree:true });
+})()
+`;
+}
+
 module.exports = {
   XBOX_HOST_RE,
   isXboxHost,
-  getGamepadPatch
+  getGamepadPatch,
+  getFocusPatch
 };

--- a/preload.js
+++ b/preload.js
@@ -1,3 +1,17 @@
+const { getFocusPatch } = require('./lib/xcloud');
+
+(function xcloudFocusPatch(){
+  try {
+    const host = (location.hostname || '').toLowerCase();
+    const isXcloud = /(^|\.)(xbox\.com|xboxlive\.com|cloudgaming|cloudapp|azureedge)\./.test(host) || /xbox\.com$/.test(host);
+    if (!isXcloud) return;
+    const s = document.createElement('script');
+    s.textContent = getFocusPatch();
+    (document.documentElement || document.head).appendChild(s);
+    s.remove();
+  } catch {}
+})();
+
 let hideCursorTimeout;
 
 function resetCursorTimeout() {


### PR DESCRIPTION
## Summary
- spoof document focus/visibility so xCloud always sees view as active
- inject focus patch via preload and expose reusable helper
- test focus patch contents

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a75ad823688321954fbee741153440