### PR TITLE
feat: highlight active xcloud tile

### DIFF
--- a/__tests__/focus-overlay.test.js
+++ b/__tests__/focus-overlay.test.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('XFOCUS_PATCH overlay', () => {
+  const src = fs.readFileSync(path.join(__dirname, '..', 'main.js'), 'utf8');
+  test('includes gp-active class', () => {
+    expect(src).toContain('gp-active');
+  });
+
+  test('patches HTMLElement.prototype.focus', () => {
+    expect(src).toMatch(/HTMLElement\.prototype\.focus/);
+  });
+});

--- a/main.js
+++ b/main.js
@@ -81,6 +81,51 @@ const XFOCUS_PATCH = `
   tryDismiss();
   const mo = new MutationObserver(tryDismiss);
   mo.observe(document.documentElement, { childList:true, subtree:true });
+
+  (() => {
+    const STYLE_ID = 'gp-focus-overlay-style';
+    const ACTIVE_CLASS = 'gp-active';
+
+    // Style toevoegen (een custom kader via pseudo-element)
+    if (!document.getElementById(STYLE_ID)) {
+      const style = document.createElement('style');
+      style.id = STYLE_ID;
+      style.textContent = \`
+        .\${ACTIVE_CLASS} {
+          position: relative !important;
+        }
+        .\${ACTIVE_CLASS}::after {
+          content: "";
+          position: absolute;
+          inset: -4px;
+          border: 3px solid #00d1ff;
+          border-radius: 12px;
+          pointer-events: none;
+          box-shadow: 0 0 8px rgba(0,209,255,.5);
+        }
+      \`;
+      document.head.appendChild(style);
+    }
+
+    const origFocus = HTMLElement.prototype.focus;
+    let last = null;
+
+    HTMLElement.prototype.focus = function(...args) {
+      // oude highlight weghalen
+      if (last && last !== this) {
+        last.classList.remove(ACTIVE_CLASS);
+      }
+
+      // dit element markeren
+      this.classList.add(ACTIVE_CLASS);
+      last = this;
+
+      // native focus wel uitvoeren (anders breek je keyboard input)
+      return origFocus.apply(this, args);
+    };
+
+    console.log("✅ .focus() gepatched: actieve tile krijgt altijd overlay.");
+  })();
 })()
 `;
 

--- a/readme.MD
+++ b/readme.MD
@@ -2,6 +2,8 @@
 
 Electron app that splits the display into four isolated browser sessions for xCloud or Remote Play. Each view scales to half of the screen's width and height—for example, on a 4K screen each view is 1080p, and on a 1080p screen each view is 540p. Every view uses its own persistent profile and only listens to a single controller.
 
+The app patches xCloud so the currently selected tile always has a visible outline, even when the OS or browser focus is elsewhere, ensuring you can see which game is highlighted while navigating with a gamepad.
+
 ## Windows setup
 
 1. **Install Node.js** – download the LTS version from [nodejs.org](https://nodejs.org) and run the installer.


### PR DESCRIPTION
## Summary
- overlay active xCloud tile even when browser focus shifts
- document permanent overlay behaviour
- test for focus overlay patch

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a84a36044883218d61d1f4ebb96d6d